### PR TITLE
Issue 21: fix typo in theme, add nav bar structure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: Provides functions for nowcasting right-truncated epidemiological
   data, based heavily on the method implemented in
   https://github.com/KITmetricslab/RESPINOW-Hub/tree/main/code/baseline
 License: MIT + file LICENSE
-URL:https:://baselinenowcast.epinowcast.org, https://github.com/epinowcast/baselinenowcast/
+URL: https://baselinenowcast.epinowcast.org, https://github.com/epinowcast/baselinenowcast/
 BugReports: https://github.com/epinowcast/baselinenowcast/issues
 Depends:
     R (>= 4.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: Provides functions for nowcasting right-truncated epidemiological
   data, based heavily on the method implemented in
   https://github.com/KITmetricslab/RESPINOW-Hub/tree/main/code/baseline
 License: MIT + file LICENSE
-URL: https://github.com/epinowcast/baselinenowcast/
+URL:https:://baselinenowcast.epinowcast.org, https://github.com/epinowcast/baselinenowcast/
 BugReports: https://github.com/epinowcast/baselinenowcast/issues
 Depends:
     R (>= 4.0.0)
@@ -44,6 +44,8 @@ Suggests:
     withr,
     knitr
 Encoding: UTF-8
+Language: en-GB
+LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,6 @@
 url: https://baselinenowcast.epinowcast.org/
 template:
-  pacakge: enwtheme
+  package: enwtheme
   math-rendering: mathjax
 
 
@@ -9,8 +9,14 @@ development:
 
 navbar:
   structure:
+    left: [intro, metareference, news]
     right: [search, github, lightswitch]
   components:
+    metareference:
+      text: Reference
+      menu:
+      - text: R reference
+        href: reference/index.html
 
 home:
   title: Baseline nowcast for right-truncated epidemiological data

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -14,9 +14,6 @@ navbar:
   components:
     metareference:
       text: Reference
-      menu:
-      - text: R reference
-        href: reference/index.html
 
 home:
   title: Baseline nowcast for right-truncated epidemiological data


### PR DESCRIPTION
## Description

This PR closes #21. It fixes the typo in the `_pkgdown.yaml` that was preventing the `enw_theme()` from working and adds the formatting to the navigation bar. 

For a separate issue, but we could add a preview of the site as a comment to the PR? I downloaded the artifact but either the theme still isn't working (possible) or the formatting doesn't seem to display

Tangentially related to formatting, I think I should make an issue to add back in the wordlist and spelling? 

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
