### PR TITLE
Issue 35: Draft of methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # baselinenowcast 0.0.0.1000
 
+-   Methods write-up as a separate vignette
 -   Introduced function to estimate the uncertainty from a triangle to be nowcasted and a delay distribution.
 -   Introduced functions to get the delay estimate and apply the delay, and used these in the Getting Started vignette.
 -   Added package skeleton.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,7 +9,16 @@ development:
 
 navbar:
   structure:
+    left: [intro, reference, articles, news]
     right: [search, github, lightswitch]
+  components:
+    articles:
+      text: Articles
+      menu:
+        - text: "Getting started"
+          href: arrticles/baselinenowcast.html
+        - text: "Mathematical model"
+          href: articles/model_definition.html
 
 
 home:

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -97,9 +97,9 @@ Where the number of reports at timepoint $t$ with delay $d$ is the product of th
 
 To extend these point nowcasts to probabilistic nowcasts, we can use the past nowcast errors. We will describe two methods for doing this, both of which generate retrospective reporting triangles to replicate would would have been available as of time $t^*=s^*$.
 
-#### Uncertainty estimate via iteratively re-estimating the delay distribution
+#### Uncertainty estimate via iteratively re-estimating the delay distribution and computing retrospective nowcasts
 
-The first method uses the retrospective incomplete reporting triangle to recompute a point nowcast using the $N$ preceding rows of the reporting triangle before $s^*$, for $M$ realizations of the retrospective reporting triangle (so $M$ different $s^*$ values).
+The first method uses the retrospective incomplete reporting triangle to re-estimate a delay distribution using the $N$ preceding rows of the reporting triangle before $s^*$, and using it to recompute a retrospective nowcast, for $M$ realizations of the retrospective reporting triangle (so $M$ different $s^*$ values).
 For each horizon $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, >d}$ assume a negative binomial observation model with a mean of $\hat{x}_{s^*-d}$:
 
 $$
@@ -108,9 +108,9 @@ $$
 
 We add a small number to the mean to avoid an ill-defined negative binomial. We note that to perform all these computations, data snapshots from at least $N +M$ past observations, or rows of the reporting triangle, are needed. This estimate of the uncertainty accounts for the empirical uncertainty in the point estimate of the delay distribution over time.
 
-#### Uncertainty estimate via generating retrospective nowcasts from the delay distribution, $\pi(d)$
+#### Uncertainty estimate via computing retrospective nowcasts from a single delay distribution, $\pi(d)$
 
-The second method uses the retrospective incomplete reporting triangles to recompute a point nowcast, using the delay distribution specified, $\pi(d)$, as is described above. Then, following the same assumption above, for each horizon $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, >d}$ assume a negative binomial observation model with a mean of $\hat{x}_{s^*-d}$:
+The second method uses the retrospective incomplete reporting triangles to recompute a point nowcast, using the delay distribution specified, $\pi(d)$, as described above. Then, following the same assumption above, for each horizon $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, >d}$ assume a negative binomial observation model with a mean of $\hat{x}_{s^*-d}$:
 
 $$
 X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi(d))

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -19,7 +19,7 @@ vignette: >
 
 # `baselinenowcast` mathematical model
 
-The following describes the estimate of the delay distribution, the generation of the point nowcast, and the estimate of the observation error, for a partially observed or complete reporting triangle. The method assumes that the units of the delays, $d$\$ and the units of reference time $t$ are the same, e.g. weekly data and weekly releases or daily data with daily releases. This method is based on the method described by ([Wolffram et al. 2023](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1011394)) developed by the Karlsruhe Institute of Technology.
+The following describes the estimate of the delay distribution, the generation of the point nowcast, and the estimate of the observation error, for a partially observed or complete reporting triangle. The method assumes that the units of the delays, $d$ and the units of reference time $t$ are the same, e.g. weekly data and weekly releases or daily data with daily releases. This method is based on the method described by ([Wolffram et al. 2023](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1011394)) developed by the Karlsruhe Institute of Technology.
 
 ### Notation
 

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -1,3 +1,22 @@
+---
+title: "Mathematical methods for `baselinenowcast`"
+description: "Description of mathematical methods used in the package"
+author: Kaitlyn Johnson
+output:
+  bookdown::html_document2:
+    fig_caption: yes
+    code_folding: show
+pkgdown:
+  as_is: true
+bibliography: library.bib
+csl: https://raw.githubusercontent.com/citation-style-language/styles/master/apa-numeric-superscript-brackets.csl
+link-citations: true
+vignette: >
+  %\VignetteIndexEntry{Mathematical methods for baselinenowcast}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
 # `baselinenowcast` mathematical model
 
 The following describes the estimate of the delay distribution, the generation of the point nowcast, and the estimate of the observation error, for a partially observed or complete reporting triangle. The method assumes that the units of the delays, $d$\$ and the units of reference time $t$ are the same, e.g. weekly data and weekly releases or daily data with daily releases. This method is based on the method described by ([Wolffram et al. 2023](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1011394)) developed by the Karlsruhe Institute of Technology.
@@ -28,7 +47,7 @@ We refer to the matrix of $x$ available at a given data release time $t^*$ , as 
 ### Point estimate of the delay distribution
 
 We use the entire reporting triangle to compute an empirical estimate of the delay distribution, $\pi(d)$, or the probability that a case at reference time $t$ appears in the dataset at time $t + d$. We will refer to the realized empirical estimate of the delay distribution from a reporting triangle as $\pi(d)$.
-The delay distribution, $\pi(d)$ can be estimated directly from the completed reporting matrix $X$ 
+The delay distribution, $\pi(d)$ can be estimated directly from the completed reporting matrix $X$
 
 $$
 {\pi}_d= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
@@ -47,11 +66,11 @@ $$
 
 *Note:* this amounts to taking the sum of the elements in column $d$ up until time $t*-d$ and dividing by the sum over all the elements to the left of column $d$ up until time $t*-d$, referred to as `block_top` and `block_top_left`, respectively, in the code.
 
-This factor is then used to compute the expected values for all the missing rows with delay $d$ as: 
+This factor is then used to compute the expected values for all the missing rows with delay $d$ as:
 
 $$
 \hat{x}_{t,d} = \hat{\theta_d}(t^*) \times \sum_{t=t^*-d}^{t^*} x_{t,d-1}
-$$ 
+$$
 
 *Note:* this amounts to effectively taking the sum across the columns in the bottom left (`block_bottom_left` in the code) of the matrix up until column $d$ and multiplying by the factor to estimate the value of $x_{t,d}$ in each row.
 This process is repeated iteratively, from bottom left to top right, to impute the bottom right triangle of the reporting matrix for each time $t$ and delay $d$ when $t+d>t^*$. The combination of the imputed and observed reporting matrix is then used to compute the delay distribution $\hat{\pi}(d)$ as described above.
@@ -85,7 +104,7 @@ For each horizon $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, 
 
 $$
 X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi_d)
-$$ 
+$$
 
 We add a small number to the mean to avoid an ill-defined negative binomial. We note that to perform all these computations, data snapshots from at least $N +M$ past observations, or rows of the reporting triangle, are needed. This estimate of the uncertainty accounts for the empirical uncertainty in the point estimate of the delay distribution over time.
 

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -31,7 +31,7 @@ Such that $X_t = X_{t, \le D}$ is the “final” number of reported cases on ti
 
 $$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
 
-is the number of cases still missing after $d$ delays.
+is the number of cases still missing after $d$ delay.
 We refer to $X_t$ to describe a random variable, $x_t$ for the corresponding observation, and $\hat{x}_t$ for an estimated/imputed value.
 We refer to the matrix of $x$ available at a given data release time $t^*$ , as the reporting triangle. Here, all $t+d>t^*$ have yet to be observed.
 

--- a/vignettes/model_definition.md
+++ b/vignettes/model_definition.md
@@ -1,48 +1,20 @@
----
-title: "Mathematical description of `baselinenowcast` method"
-output: html_document
-editor_options:
-  markdown:
-    wrap: 72
----
+# `baselinenowcast` mathematical model
 
-## `baselinenowcast` mathematical model
-
-The following describes the estimate of the delay distribution, the
-generation of the point nowcast, and the estimate of the observation
-error, for a partially observed or complete reporting triangle. The
-method assumes that the units of the delays, $d$\$ and the units of
-reference time $t$ are the same, e.g. weekly data and weekly releases or
-daily data with daily releases. This method is based on the method
-described by (Wolffram et al. 2023) developed by the Karlsruhe Institute
-of Technology.
+The following describes the estimate of the delay distribution, the generation of the point nowcast, and the estimate of the observation error, for a partially observed or complete reporting triangle. The method assumes that the units of the delays, $d$\$ and the units of reference time $t$ are the same, e.g. weekly data and weekly releases or daily data with daily releases. This method is based on the method described by (Wolffram et al. 2023) developed by the Karlsruhe Institute of Technology.
 
 ### Notation
 
-We denote $X_{t,d}, d = 0, .., D$ as the number of cases occurring on
-time $t$ which appear in the dataset with a delay of $d$. For example, a
-delay $d = 0$ means that a case occurring on day $t$ arrived in the
-dataset on day $t$, or on what is considered to be the first possible
-report date in practice. We only consider cases reporting within a
-maximum delay $D$. The number of cases reporting for time $t$ with a
-delay of at most $d$ can be written as:
+We denote $X_{t,d}, d = 0, .., D$ as the number of cases occurring on time $t$ which appear in the dataset with a delay of $d$. For example, a delay $d = 0$ means that a case occurring on day $t$ arrived in the dataset on day $t$, or on what is considered to be the first possible report date in practice. We only consider cases reporting within a maximum delay $D$. The number of cases reporting for time $t$ with a delay of at most $d$ can be written as:
 
 $$X_{t, \le d} = \sum_{i=0}^d X_{t,i} $$
 
-Such that $X_t = X_{t, \le D}$ is the “final” number of reported cases
-on time $t$. Conversely, for $d < D$
+Such that $X_t = X_{t, \le D}$ is the “final” number of reported cases on time $t$. Conversely, for $d < D$
 
 $$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
 
 is the number of cases still missing after $d$ delays.
-
-We refer to $X_t$ to describe a random variable, $x_t$ for the
-corresponding observation, and $\hat{x}_t$ for an estimated/imputed
-value.
-
-We refer to the matrix of $x$ available at a given data release time
-$t^*$, as the reporting triangle. Here, all $t+d > t^*$ have yet to be
-observed.
+We refer to $X_t$ to describe a random variable, $x_t$ for the corresponding observation, and $\hat{x}_t$ for an estimated/imputed value.
+We refer to the matrix of $x$ available at a given data release time $t^*$ , as the reporting triangle. Here, all $t+d>t^*$ have yet to be observed.
 
 |   | $d = 0$ | $d = 1$ | $d=2$ | $...$ | $d= D-1$ | $d= D$ |
 |-----------|-----------|-----------|-----------|-----------|-----------|-----------|
@@ -55,153 +27,84 @@ observed.
 
 ### Point estimate of the delay distribution
 
-We use the entire reporting triangle to compute an empirical estimate of
-the delay distribution, $\pi(d)$, or the probability that a case at
-reference time $t$ appears in the dataset at time $t + d$. We will refer
-to the realized empirical estimate of the delay distribution from a
-reporting triangle as $\hat{\pi}(d)$.
+We use the entire reporting triangle to compute an empirical estimate of the delay distribution, $\pi(d)$, or the probability that a case at reference time $t$ appears in the dataset at time $t + d$. We will refer to the realized empirical estimate of the delay distribution from a reporting triangle as $\hat{\pi}(d)$.
+The delay distribution, $\pi(d)$ can be estimated directly from the completed reporting matrix $X$ 
 
-The delay distribution, $\pi(d)$ can be estimated directly from the
-completed reporting matrix $X$ $$
+$$
 {\pi}_d= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
 $$
 
-In the special case when the time the estimate is made $t'$, is beyond
-the data release time $t^{*}$, such that $t' \ge t^* + D$, $\hat{\pi}_d$
-can be computed directly by summing over all reference time points $t$
-at each delay $d$.
-
-In the case where there are partial observations, in order to properly
-weight the denominator with the missing delays, we have to first impute
-the cases $\hat{x}_{t,d}$ for all instances where $t+d > t^*$. This
-amounts to computing the point nowcast from the partial reporting
-triangle.
+In the special case when the time the estimate is made $t'$, is beyond the data release time $t^{*}$, such that $t' \ge t^* + D$, $\hat{\pi}_d$ can be computed directly by summing over all reference time points $t$ at each delay $d$.
+In the case where there are partial observations, in order to properly weight the denominator with the missing delays, we have to first impute the cases $\hat{x}_{t,d}$ for all instances where $t+d > t^*$. This amounts to computing the point nowcast from the partial reporting triangle.
 
 ### Point nowcast from incomplete reporting matrix
 
-To do so, we start by defining $\theta_d$, which is the factor by which
-the cases on delay $d$ compare to the total cases through delay $d-1$,
-obtained from $N$ preceding rows of the triangle. In practice,
-$N \ge D$, with any $N > D$ representing the number of completed
-observations used to inform the estimate
+To do so, we start by defining $\theta_d$, which is the factor by which the cases on delay $d$ compare to the total cases through delay $d-1$, obtained from $N$ preceding rows of the triangle. In practice, $N \ge D$, with any $N > D$ representing the number of completed observations used to inform the estimate
 
 $$
 \hat{\theta}_d(t^*) = \frac{\sum_{i=1}^{N} x_{t^*-i+d, d}}{\sum_{d=1}^{d-1} \sum_{i=1}^{N} x_{t^*-i+d,d}}
 $$
 
-*Note:* this amounts to taking the sum of the elements in column $d$ up
-until time $t*-d$ and dividing by the sum over all the elements to the
-left of column $d$ up until time $t*-d$, referred to as `block_top` and
-`block_top_left`, respectively, in the code.
+*Note:* this amounts to taking the sum of the elements in column $d$ up until time $t*-d$ and dividing by the sum over all the elements to the left of column $d$ up until time $t*-d$, referred to as `block_top` and `block_top_left`, respectively, in the code.
 
-This factor is then used to compute the expected values for all the
-missing rows with delay $d$ as: $$
+This factor is then used to compute the expected values for all the missing rows with delay $d$ as: 
+
+$$
 \hat{x}_{t,d} = \hat{\theta_d}(t^*) \times \sum_{t=t^*-d}^{t^*} x_{t,d-1}
-$$ *Note:* this amounts to effectively taking the sum across the columns
-in the bottom left (`block_bottom_left` in the code) of the matrix up
-until column $d$ and multiplying by the factor to estimate the value of
-$x_{t,d}$ in each row.
+$$ 
 
-This process is repeated iteratively, from bottom left to top right, to
-impute the bottom right triangle of the reporting matrix for each time
-$t$ and delay $d$ when $t+d>t^*$. The combination of the imputed and
-observed reporting matrix is then used to compute the delay distribution
-$\hat{\pi}(d)$ as described above.
-
-The factor, $\theta_d$ can only be computed for delays greater than 0,
-which effectively means that a row of the reporting triangle without any
-observations, can not be imputed as the process works iteratively.
-Therefore, the reporting matrix must have at least an entry (though it
-can be 0) for $x_{t*,d=0}$ to compute a nowcast for $t^*$. We will
-describe the method for estimating nowcasts for zero-valued counts
-below.
-
-The method desribed above uses the incomplete reporting triangle to
-iteratively compute a point nowcast. We can also use the delay
-distribution $\hat{\pi(d)}$ directly to compute a point nowcast, which
-can be useful if, for example, the delay distribution is estimated from
-different strata or as part of a separate estimate.
+*Note:* this amounts to effectively taking the sum across the columns in the bottom left (`block_bottom_left` in the code) of the matrix up until column $d$ and multiplying by the factor to estimate the value of $x_{t,d}$ in each row.
+This process is repeated iteratively, from bottom left to top right, to impute the bottom right triangle of the reporting matrix for each time $t$ and delay $d$ when $t+d>t^*$. The combination of the imputed and observed reporting matrix is then used to compute the delay distribution $\hat{\pi}(d)$ as described above.
+The factor, $\theta_d$ can only be computed for delays greater than 0, which effectively means that a row of the reporting triangle without any observations, can not be imputed as the process works iteratively. Therefore, the reporting matrix must have at least an entry (though it can be 0) for $x_{t*,d=0}$ to compute a nowcast for $t^*$. We will describe the method for estimating nowcasts for zero-valued counts below.
+The method described above uses the incomplete reporting triangle to iteratively compute a point nowcast. We can also use the delay distribution $\hat{\pi(d)}$ directly to compute a point nowcast, which can be useful if, for example, the delay distribution is estimated from different strata or as part of a separate estimate.
 
 ### Point nowcast from delay distribution $\pi(d)$
 
-We start by computing the expected total number of eventual observed
-cases $\hat{x}_t$, for each reference time $t$, by summing over all
-delays $d$ that have already been observed (up until $t^*-t$) and
-dividing by the cumulative sum of the delay distribution, $\pi(d)$ up
-until $d = t^*-t$.
+We start by computing the expected total number of eventual observed cases $\hat{x}_t$, for each reference time $t$, by summing over all delays $d$ that have already been observed (up until $t^*-t$) and dividing by the cumulative sum of the delay distribution, $\pi(d)$ up until $d = t^*-t$.
 
 $$
 \hat{x}_t= \frac{\sum_{d=1}^{d=t^*-t} x_{t,d}}{\sum_{d=1}^{d=t^*-t} \\pi(d)}
 $$
 
-Then we can compute $\hat{x}_{t,d}$ directly using the $d$th element of
-$\pi(d)$
+Then we can compute $\hat{x}_{t,d}$ directly using the $d$th element of $\pi(d)$
 
 $$
 \hat{x}_{t,d} = \pi(d) \times \hat{x}_t
 $$
 
-Where the number of reports at timepoint $t$ with delay $d$ is the
-product of the the expected total reports, $x_t$ and the proportion
-expected at that particular delay $d$, $\pi(d)$.
+Where the number of reports at timepoint $t$ with delay $d$ is the product of the the expected total reports, $x_t$ and the proportion expected at that particular delay $d$, $\pi(d)$.
 
 ### Estimate of uncertainty in the nowcast
 
-To extend these point nowcasts to probabilistic nowcasts, we can use the
-past nowcast errors. We will describe two methods for doing this, both
-of which generate retrospective reporting triangles to replicate would
-would have been available as of time $t^*=s^*$.
+To extend these point nowcasts to probabilistic nowcasts, we can use the past nowcast errors. We will describe two methods for doing this, both of which generate retrospective reporting triangles to replicate would would have been available as of time $t^*=s^*$.
 
 #### Uncertainty estimate via iteratively re-estimating the delay distribution
 
-The first method uses the retrospective incomplete reporting triangle to
-recompute a point nowcast using the $N$ preceding rows of the reporting
-triangle before $s^*$, for $M$ realizations of the retrospective
-reporting triangle (so $M$ different $s^*$ values).
-
-For each horizon $d = 1, ..., D$ we assume that the observed values,
-$X_{s^*-d, >d}$ assume a negative binomial observation model with a mean
-of $\hat{x}_{s^*-d}$:
+The first method uses the retrospective incomplete reporting triangle to recompute a point nowcast using the $N$ preceding rows of the reporting triangle before $s^*$, for $M$ realizations of the retrospective reporting triangle (so $M$ different $s^*$ values).
+For each horizon $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, >d}$ assume a negative binomial observation model with a mean of $\hat{x}_{s^*-d}$:
 
 $$
 X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi_d)
-$$
-We add a small number to the mean to avoid an ill-defined negative binomial.
-We note that to perform all these computations, data snapshots from at
-least $N +M$ past observations, or rows of the reporting triangle, are
-needed. This estimate of the uncertainty accounts for the empirical
-uncertainty in the point estimate of the delay distribution over time.
+$$ 
 
+We add a small number to the mean to avoid an ill-defined negative binomial. We note that to perform all these computations, data snapshots from at least $N +M$ past observations, or rows of the reporting triangle, are needed. This estimate of the uncertainty accounts for the empirical uncertainty in the point estimate of the delay distribution over time.
 
 #### Uncertainty estimate via generating retrospective nowcasts from the delay distribution, $\pi(d)$
 
-The second method uses the retrospective incomplete reporting triangles
-to recompute a point nowcast, using the delay distribution specified,
-$\pi(d)$, as is described above. Then, following the same assumption
-above, for each horizon $d = 1, ..., D$ we assume that the observed values,
-$X_{s^*-d, >d}$ assume a negative binomial observation model with a mean
-of $\hat{x}_{s^*-d}$:
+The second method uses the retrospective incomplete reporting triangles to recompute a point nowcast, using the delay distribution specified, $\pi(d)$, as is described above. Then, following the same assumption above, for each horizon $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, >d}$ assume a negative binomial observation model with a mean of $\hat{x}_{s^*-d}$:
 
 $$
 X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi(d))
 $$
-Where again, we add a small number to avoid an ill-defined negative binomial.
-We note that in this estimate of uncertainty, data snapshots from $M$ past
-observations, or rows of the reporting triangle, are needed, as we do not
-need to use any other rows to generate the point nowcasts.
-We suggest using this estimate of the uncertainty if you suspect that the delay
-distribution that you are using may be misspecified, for example, if it was
-estimated from a different strata.
+
+Where again, we add a small number to avoid an ill-defined negative binomial. We note that in this estimate of uncertainty, data snapshots from $M$ past observations, or rows of the reporting triangle, are needed, as we do not need to use any other rows to generate the point nowcasts. We suggest using this estimate of the uncertainty if you suspect that the delay distribution that you are using may be misspecified, for example, if it was estimated from a different strata.
 
 ### Generating probabilistic nowcasts
 
-Using the dispersion parameters for each delay, $\phi(d)$ for $d = 1,...D$,
-we can generate probabilistic nowcasts by drawing samples from the
-negative binomial:
+Using the dispersion parameters for each delay, $\phi(d)$ for $d = 1,...D$, we can generate probabilistic nowcasts by drawing samples from the negative binomial:
 
 $$
 X_{t,d} \sim NegBin(\mu = \hat{x}_{t,d}, \phi = phi(d))
 $$
 
-We can sample for any number of draws, and then use the draws to compute
-any desired quantiles to summarize the outputs.
+We can sample for any number of draws, and then use the draws to compute any desired quantiles to summarize the outputs.

--- a/vignettes/model_definition.md
+++ b/vignettes/model_definition.md
@@ -29,8 +29,8 @@ delay of at most $d$ can be written as:
 
 $$X_{t, \le d} = \sum_{i=0}^d X_{t,i} $$
 
-Such that $X_t = X{t, \le D}$ is the “final” number of reported cases on
-time $t$. Conversely, for $d < D$
+Such that $X_t = X_{t, \le D}$ is the “final” number of reported cases
+on time $t$. Conversely, for $d < D$
 
 $$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
 
@@ -44,33 +44,32 @@ We refer to the matrix of $x$ available at a given data release time
 $t^*$, as the reporting triangle. Here, all $t+d > t^*$ have yet to be
 observed.
 
--   Need to fix alignment so this looks like a table. $$
-    \begin{align}
-    x_{1,1} \ x_{1,2} \ x_{1,3} \ ... \ x_{1, D-1} \ x_{1,D} \\
-    x_{2,1} \ x_{2,2} \ x_{2,3} \ ... \ x_{2, D-1} \ x_{2,D} \\
-    x_{3,1} \ x_{3,2} \ x_{3,3} \ ... \ x_{3, D-1} \ x_{3,D} \\
-    x_{t^*-1, 1} \ x_{t^*-1, 2} \ x_{t^*-1, 3} \ ... \ x_{t^*-1, D-1}, x_{t^*-1, D} \\
-    x_{t^*, 1} \ x_{t^*, 2} \ x_{t^*, 3} \ ... \ x_{t^*, D-1}, x_{t^*, D}
-    \end{align}
-    $$
+|   | $d = 0$ | $d = 1$ | $d=2$ | $...$ | $d= D-1$ | $d= D$ |
+|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
+| $t=1$ | $x_{1,0}$ | $x_{1,1}$ | $x_{1,2}$ | $...$ | $x_{1,D-1}$ | $x_{1, D}$ |
+| $t=2$ | $x_{2,0}$ | $x_{2,1}$ | $x_{2,2}$ | $...$ | $x_{2,D-1}$ | $x_{2, D}$ |
+| $t=3$ | $x_{3,0}$ | $x_{3,1}$ | $x_{3,2}$ | $...$ | $x_{3,D-1}$ | $x_{3, D}$ |
+| $...$ | $...$ | $...$ | $...$ | $...$ | $...$ | $...$ |
+| $t=t^*-1$ | $x_{t^*-1,0}$ | $x_{t^*-1,1}$ | $x_{t^*-1,,2}$ | $...$ | $x_{t^*-1,,D-1}$ | $x_{t^*-1,D}$ |
+| $t=t^*$ | $x_{t^*,0}$ | $x_{t^*,1}$ | $x_{t^*,2}$ | $...$ | $x_{t^*,D-1}$ | $x_{t^*, D}$ |
 
 ### Point estimate of the delay distribution
 
 We use the entire reporting triangle to compute an empirical estimate of
-the delay distribution, $\rho(d)$, or the probability that a case at
+the delay distribution, $\pi(d)$, or the probability that a case at
 reference time $t$ appears in the dataset at time $t + d$. We will refer
 to the realized empirical estimate of the delay distribution from a
-reporting triangle as $\hat{\rho}(d)$.
+reporting triangle as $\hat{\pi}(d)$.
 
-The delay distribution, $\rho(d)$ can be estimated directly from the
+The delay distribution, $\pi(d)$ can be estimated directly from the
 completed reporting matrix $X$ $$
-{\rho}_d= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
+{\pi}_d= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
 $$
 
 In the special case when the time the estimate is made $t'$, is beyond
-the data release time $t^{*}$, such that $t' \ge t^* + D$,
-$\hat{\rho}_d$ can be computed directly by summing over all reference
-time points $t$ at each delay $d$.
+the data release time $t^{*}$, such that $t' \ge t^* + D$, $\hat{\pi}_d$
+can be computed directly by summing over all reference time points $t$
+at each delay $d$.
 
 In the case where there are partial observations, in order to properly
 weight the denominator with the missing delays, we have to first impute
@@ -81,33 +80,33 @@ triangle.
 ### Point nowcast from incomplete reporting matrix
 
 To do so, we start by defining $\theta_d$, which is the factor by which
-the cases on delay $d$ compare to the total cases through delay $d-1$, obtained
-from $N$ preceding rows of the triangle.
-In practice, $N >= D$, with any $N > D$ representing the number of completed
+the cases on delay $d$ compare to the total cases through delay $d-1$,
+obtained from $N$ preceding rows of the triangle. In practice,
+$N \ge D$, with any $N > D$ representing the number of completed
 observations used to inform the estimate
 
 $$
 \hat{\theta}_d(t^*) = \frac{\sum_{i=1}^{N} x_{t^*-i+d, d}}{\sum_{d=1}^{d-1} \sum_{i=1}^{N} x_{t^*-i+d,d}}
 $$
 
-*Note this amounts to taking the sum of the elements in column $d$
-up until time $t*-d$ and dividing by the sum over all the elements to
-the left of column $d$ up until time $t*-d$, referred to as `block_top`
-and `block_top_left` in the code *
+*Note:* this amounts to taking the sum of the elements in column $d$ up
+until time $t*-d$ and dividing by the sum over all the elements to the
+left of column $d$ up until time $t*-d$, referred to as `block_top` and
+`block_top_left`, respectively, in the code.
 
 This factor is then used to compute the expected values for all the
 missing rows with delay $d$ as: $$
 \hat{x}_{t,d} = \hat{\theta_d}(t^*) \times \sum_{t=t^*-d}^{t^*} x_{t,d-1}
-$$ \* Note this amounts to effectively taking the sum across the columns
+$$ *Note:* this amounts to effectively taking the sum across the columns
 in the bottom left (`block_bottom_left` in the code) of the matrix up
 until column $d$ and multiplying by the factor to estimate the value of
-$x_{t,d}$ in each row. \*
+$x_{t,d}$ in each row.
 
-This process is repeated iteratively, from left to right, to impute the
-bottom right triangle of the reporting matrix for each time $t$ and
-delay $d$ when $t+d>t^*$. The combination of the imputed and observed
-reporting matrix is then used to compute the delay distribution
-$\hat{\rho}(d)$ as described above.
+This process is repeated iteratively, from bottom left to top right, to
+impute the bottom right triangle of the reporting matrix for each time
+$t$ and delay $d$ when $t+d>t^*$. The combination of the imputed and
+observed reporting matrix is then used to compute the delay distribution
+$\hat{\pi}(d)$ as described above.
 
 The factor, $\theta_d$ can only be computed for delays greater than 0,
 which effectively means that a row of the reporting triangle without any
@@ -117,32 +116,92 @@ can be 0) for $x_{t*,d=0}$ to compute a nowcast for $t^*$. We will
 describe the method for estimating nowcasts for zero-valued counts
 below.
 
-We can then use the delay distribution $\hat{\rho(d)}$ to compute
-directly a point nowcast, without the iterative imputation to complete
-the reporting triangle.
+The method desribed above uses the incomplete reporting triangle to
+iteratively compute a point nowcast. We can also use the delay
+distribution $\hat{\pi(d)}$ directly to compute a point nowcast, which
+can be useful if, for example, the delay distribution is estimated from
+different strata or as part of a separate estimate.
 
-### Point nowcast from delay distribution $\rho(d)$
-
-The point nowcast of an incomplete reporting triangle can be computed
-directly from the delay distribution, $\rho(d)$.
+### Point nowcast from delay distribution $\pi(d)$
 
 We start by computing the expected total number of eventual observed
 cases $\hat{x}_t$, for each reference time $t$, by summing over all
-delays $d$ that have already been observed (up until $t*-t$) and
-dividing by the cumulative sum of the delay distribution
+delays $d$ that have already been observed (up until $t^*-t$) and
+dividing by the cumulative sum of the delay distribution, $\pi(d)$ up
+until $d = t^*-t$.
 
 $$
-\hat{x}_t= \frac{\sum_{d=1}^{d=t*-t} x_{t,d}}{\sum_{d=1}^{d=t*-t} \hat{\rho}(d)}
+\hat{x}_t= \frac{\sum_{d=1}^{d=t^*-t} x_{t,d}}{\sum_{d=1}^{d=t^*-t} \\pi(d)}
 $$
 
-Then we can compute $\hat{x}_t,d$ directly using the $d$th element of
-$\hat{\rho}(d)$
+Then we can compute $\hat{x}_{t,d}$ directly using the $d$th element of
+$\pi(d)$
 
-\$\$ \hat{x}\_{t,d} = \hat{\rho}(d) \times \hat{x}\_t
+$$
+\hat{x}_{t,d} = \pi(d) \times \hat{x}_t
+$$
 
-\$\$ Here we multiply the expected total by the proportion expected at
-that particular delay $d$.
+Where the number of reports at timepoint $t$ with delay $d$ is the
+product of the the expected total reports, $x_t$ and the proportion
+expected at that particular delay $d$, $\pi(d)$.
 
 ### Estimate of uncertainty in the nowcast
 
-*Filling in tomorrow*
+To extend these point nowcasts to probabilistic nowcasts, we can use the
+past nowcast errors. We will describe two methods for doing this, both
+of which generate retrospective reporting triangles to replicate would
+would have been available as of time $t^*=s^*$.
+
+#### Uncertainty estimate via iteratively re-estimating the delay distribution
+
+The first method uses the retrospective incomplete reporting triangle to
+recompute a point nowcast using the $N$ preceding rows of the reporting
+triangle before $s^*$, for $M$ realizations of the retrospective
+reporting triangle (so $M$ different $s^*$ values).
+
+For each horizon $d = 1, ..., D$ we assume that the observed values,
+$X_{s^*-d, >d}$ assume a negative binomial observation model with a mean
+of $\hat{x}_{s^*-d}$:
+
+$$
+X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi_d)
+$$
+We add a small number to the mean to avoid an ill-defined negative binomial.
+We note that to perform all these computations, data snapshots from at
+least $N +M$ past observations, or rows of the reporting triangle, are
+needed. This estimate of the uncertainty accounts for the empirical
+uncertainty in the point estimate of the delay distribution over time.
+
+
+#### Uncertainty estimate via generating retrospective nowcasts from the delay distribution, $\pi(d)$
+
+The second method uses the retrospective incomplete reporting triangles
+to recompute a point nowcast, using the delay distribution specified,
+$\pi(d)$, as is described above. Then, following the same assumption
+above, for each horizon $d = 1, ..., D$ we assume that the observed values,
+$X_{s^*-d, >d}$ assume a negative binomial observation model with a mean
+of $\hat{x}_{s^*-d}$:
+
+$$
+X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi(d))
+$$
+Where again, we add a small number to avoid an ill-defined negative binomial.
+We note that in this estimate of uncertainty, data snapshots from $M$ past
+observations, or rows of the reporting triangle, are needed, as we do not
+need to use any other rows to generate the point nowcasts.
+We suggest using this estimate of the uncertainty if you suspect that the delay
+distribution that you are using may be misspecified, for example, if it was
+estimated from a different strata.
+
+### Generating probabilistic nowcasts
+
+Using the dispersion parameters for each delay, $\phi(d)$ for $d = 1,...D$,
+we can generate probabilistic nowcasts by drawing samples from the
+negative binomial:
+
+$$
+X_{t,d} \sim NegBin(\mu = \hat{x}_{t,d}, \phi = phi(d))
+$$
+
+We can sample for any number of draws, and then use the draws to compute
+any desired quantiles to summarize the outputs.

--- a/vignettes/model_definition.md
+++ b/vignettes/model_definition.md
@@ -27,7 +27,7 @@ We refer to the matrix of $x$ available at a given data release time $t^*$ , as 
 
 ### Point estimate of the delay distribution
 
-We use the entire reporting triangle to compute an empirical estimate of the delay distribution, $\pi(d)$, or the probability that a case at reference time $t$ appears in the dataset at time $t + d$. We will refer to the realized empirical estimate of the delay distribution from a reporting triangle as $\hat{\pi}(d)$.
+We use the entire reporting triangle to compute an empirical estimate of the delay distribution, $\pi(d)$, or the probability that a case at reference time $t$ appears in the dataset at time $t + d$. We will refer to the realized empirical estimate of the delay distribution from a reporting triangle as $\pi(d)$.
 The delay distribution, $\pi(d)$ can be estimated directly from the completed reporting matrix $X$ 
 
 $$

--- a/vignettes/model_definition.md
+++ b/vignettes/model_definition.md
@@ -1,127 +1,135 @@
 ---
 title: "Mathematical description of `baselinenowcast` method"
 output: html_document
+editor_options:
+  markdown:
+    wrap: 72
 ---
 
 ## `baselinenowcast` mathematical model
 
-The following describes the estimate of the delay distribution, the generation
-of the point nowcast, and the estimate of the observation error, for a
-partially observed or complete reporting triangle.
-The method assumes that the units of the delays, $d$$ and the units of
+The following describes the estimate of the delay distribution, the
+generation of the point nowcast, and the estimate of the observation
+error, for a partially observed or complete reporting triangle. The
+method assumes that the units of the delays, $d$\$ and the units of
 reference time $t$ are the same, e.g. weekly data and weekly releases or
-daily data with daily releases.
-This method is based on the method described by (Wolffram et al. 2023)
-developed by the Karlsruhe Institute of Technology.
+daily data with daily releases. This method is based on the method
+described by (Wolffram et al. 2023) developed by the Karlsruhe Institute
+of Technology.
 
 ### Notation
 
-We denote $X_{t,d}, d = 0, .., D$ as the number of cases occurring on time $t$
-which appear in the dataset with a delay of $d$.
-For example, a delay $d = 0$ means that a case occurring on day $t$ arrived
-in the dataset on day $t$, or on what is considered to be the first possible
-report date in practice.
-We only consider cases reporting within a maximum delay $D$.
-The number of cases reporting for time $t$ with a delay of at most $d$ can be
-written as:
+We denote $X_{t,d}, d = 0, .., D$ as the number of cases occurring on
+time $t$ which appear in the dataset with a delay of $d$. For example, a
+delay $d = 0$ means that a case occurring on day $t$ arrived in the
+dataset on day $t$, or on what is considered to be the first possible
+report date in practice. We only consider cases reporting within a
+maximum delay $D$. The number of cases reporting for time $t$ with a
+delay of at most $d$ can be written as:
 
 $$X_{t, \le d} = \sum_{i=0}^d X_{t,i} $$
 
-Such that $X_t = X{t, \le D}$ is the “final” number of reported cases on time $t$. Conversely, for $d < D$
+Such that $X_t = X{t, \le D}$ is the “final” number of reported cases on
+time $t$. Conversely, for $d < D$
 
 $$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
 
 is the number of cases still missing after $d$ delays.
 
-We refer to $X_t$ to describe a random variable, $x_t$ for the corresponding
-observation, and $\hat{x}_t$ for an estimated/imputed value.
+We refer to $X_t$ to describe a random variable, $x_t$ for the
+corresponding observation, and $\hat{x}_t$ for an estimated/imputed
+value.
 
-We refer to the matrix of $x$ available at a given data release time $t^*$,
-as the reporting triangle. Here, all $t+d > t^*$ have yet to be observed.
+We refer to the matrix of $x$ available at a given data release time
+$t^*$, as the reporting triangle. Here, all $t+d > t^*$ have yet to be
+observed.
 
-* Need to fix alignment so this looks like a table.
-$$
-\begin{align}
-x_{1,1} \ x_{1,2} \ x_{1,3} \ ... \ x_{1, D-1} \ x_{1,D} \\
-x_{2,1} \ x_{2,2} \ x_{2,3} \ ... \ x_{2, D-1} \ x_{2,D} \\
-x_{3,1} \ x_{3,2} \ x_{3,3} \ ... \ x_{3, D-1} \ x_{3,D} \\
-x_{t^*-1, 1} \ x_{t^*-1, 2} \ x_{t^*-1, 3} \ ... \ x_{t^*-1, D-1}, x_{t^*-1, D} \\
-x_{t^*, 1} \ x_{t^*, 2} \ x_{t^*, 3} \ ... \ x_{t^*, D-1}, x_{t^*, D}
-\end{align}
-$$
+-   Need to fix alignment so this looks like a table. $$
+    \begin{align}
+    x_{1,1} \ x_{1,2} \ x_{1,3} \ ... \ x_{1, D-1} \ x_{1,D} \\
+    x_{2,1} \ x_{2,2} \ x_{2,3} \ ... \ x_{2, D-1} \ x_{2,D} \\
+    x_{3,1} \ x_{3,2} \ x_{3,3} \ ... \ x_{3, D-1} \ x_{3,D} \\
+    x_{t^*-1, 1} \ x_{t^*-1, 2} \ x_{t^*-1, 3} \ ... \ x_{t^*-1, D-1}, x_{t^*-1, D} \\
+    x_{t^*, 1} \ x_{t^*, 2} \ x_{t^*, 3} \ ... \ x_{t^*, D-1}, x_{t^*, D}
+    \end{align}
+    $$
 
 ### Point estimate of the delay distribution
-We use the entire reporting triangle to compute an empirical estimate of the
-delay distribution, $\rho(d)$, or the probability that a case at reference time
-$t$ appears in the dataset at time $t + d$.
-We will refer to the realized empirical estimate of the delay distribution from a reporting triangle as $\hat{\rho}(d)$.
 
-The delay distribution, $\rho(d)$ can be estimated directly from the completed reporting matrix $X$
-$$
+We use the entire reporting triangle to compute an empirical estimate of
+the delay distribution, $\rho(d)$, or the probability that a case at
+reference time $t$ appears in the dataset at time $t + d$. We will refer
+to the realized empirical estimate of the delay distribution from a
+reporting triangle as $\hat{\rho}(d)$.
+
+The delay distribution, $\rho(d)$ can be estimated directly from the
+completed reporting matrix $X$ $$
 {\rho}_d= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
 $$
 
-In the special case when the time the estimate is made $t'$, is beyond the data
-release time $t^{*}$, such that $t' \ge t^* + D$, $\hat{\rho}_d$ can be
-computed directly by summing over all reference time points $t$  at each
-delay $d$.
+In the special case when the time the estimate is made $t'$, is beyond
+the data release time $t^{*}$, such that $t' \ge t^* + D$,
+$\hat{\rho}_d$ can be computed directly by summing over all reference
+time points $t$ at each delay $d$.
 
-In the case where there are partial observations, in order to properly weight
-the denominator with the missing delays, we have to first impute the cases
-$\hat{x}_{t,d}$ for all instances where $t+d > t^*$.
-This amounts to computing the point nowcast from the partial reporting triangle.
+In the case where there are partial observations, in order to properly
+weight the denominator with the missing delays, we have to first impute
+the cases $\hat{x}_{t,d}$ for all instances where $t+d > t^*$. This
+amounts to computing the point nowcast from the partial reporting
+triangle.
 
 ### Point nowcast from incomplete reporting matrix
 
-To do so, we start by defining $\theta_d$, which is the factor by which the
-cases on delay $d$ compare to the total cases through delay $d-1$, which can be
-computed as:
+To do so, we start by defining $\theta_d$, which is the factor by which
+the cases on delay $d$ compare to the total cases through delay $d-1$, obtained
+from $N$ preceding rows of the triangle.
+In practice, $N >= D$, with any $N > D$ representing the number of completed
+observations used to inform the estimate
 
 $$
-\hat{\theta}_d(t^*) = \frac{\sum_{t=1}^{t^*- d } x_{t, d}}{\sum_{d=1}^{d-1} \sum_{t=1}^{t^*-d} x_{t,d}}
+\hat{\theta}_d(t^*) = \frac{\sum_{i=1}^{N} x_{t^*-i+d, d}}{\sum_{d=1}^{d-1} \sum_{i=1}^{N} x_{t^*-i+d,d}}
 $$
-*Note this amounts to taking the sum of the elements in column $d$ up until time
-$t*-d$ and dividing by the sum over all the elements to the left of column $d$
-up until time $t*-d$, referred to as `block_top` and `block_top_left` in the
-code *
 
-This factor is then used to compute the expected values for all the missing
-rows with delay $d$ as:
-$$
+*Note this amounts to taking the sum of the elements in column $d$
+up until time $t*-d$ and dividing by the sum over all the elements to
+the left of column $d$ up until time $t*-d$, referred to as `block_top`
+and `block_top_left` in the code *
+
+This factor is then used to compute the expected values for all the
+missing rows with delay $d$ as: $$
 \hat{x}_{t,d} = \hat{\theta_d}(t^*) \times \sum_{t=t^*-d}^{t^*} x_{t,d-1}
-$$
-* Note this amounts to effectively taking the sum across the columns in the
-bottom left (`block_bottom_left` in the code) of the matrix up until column
-$d$ and multiplying by the factor to estimate the value of $x_{t,d}$ in
-each row. *
+$$ \* Note this amounts to effectively taking the sum across the columns
+in the bottom left (`block_bottom_left` in the code) of the matrix up
+until column $d$ and multiplying by the factor to estimate the value of
+$x_{t,d}$ in each row. \*
 
-This process is repeated iteratively, from left to right, to impute the bottom
-right triangle of the reporting matrix for each time $t$ and delay $d$ when
-$t+d>t^*$.
-The combination of the imputed and observed reporting matrix is then used to
-compute the delay distribution $\hat{\rho}(d)$ as described above.
+This process is repeated iteratively, from left to right, to impute the
+bottom right triangle of the reporting matrix for each time $t$ and
+delay $d$ when $t+d>t^*$. The combination of the imputed and observed
+reporting matrix is then used to compute the delay distribution
+$\hat{\rho}(d)$ as described above.
 
-The factor, $\theta_d$ can only be computed for delays greater than 0, which
-effectively means that a row of the reporting triangle without any
+The factor, $\theta_d$ can only be computed for delays greater than 0,
+which effectively means that a row of the reporting triangle without any
 observations, can not be imputed as the process works iteratively.
-Therefore, the reporting matrix must have at least an entry (though it can be
-0) for $x_{t*,d=0}$ to compute a nowcast for $t^*$.
-We will describe the method for estimating nowcasts for zero-valued counts
+Therefore, the reporting matrix must have at least an entry (though it
+can be 0) for $x_{t*,d=0}$ to compute a nowcast for $t^*$. We will
+describe the method for estimating nowcasts for zero-valued counts
 below.
 
-We can then use the delay distribution $\hat{\rho(d)}$ to compute directly
-a point nowcast, without the iterative imputation to complete the reporting
-triangle.
-
+We can then use the delay distribution $\hat{\rho(d)}$ to compute
+directly a point nowcast, without the iterative imputation to complete
+the reporting triangle.
 
 ### Point nowcast from delay distribution $\rho(d)$
-The point nowcast of an incomplete reporting triangle can be computed directly
-from the delay distribution, $\rho(d)$.
 
-We start by computing the expected total number of eventual observed cases
-$\hat{x}_t$, for each reference time $t$, by summing over all delays $d$ that
-have already been observed (up until $t*-t$) and dividing by the cumulative sum
-of the delay distribution
+The point nowcast of an incomplete reporting triangle can be computed
+directly from the delay distribution, $\rho(d)$.
+
+We start by computing the expected total number of eventual observed
+cases $\hat{x}_t$, for each reference time $t$, by summing over all
+delays $d$ that have already been observed (up until $t*-t$) and
+dividing by the cumulative sum of the delay distribution
 
 $$
 \hat{x}_t= \frac{\sum_{d=1}^{d=t*-t} x_{t,d}}{\sum_{d=1}^{d=t*-t} \hat{\rho}(d)}
@@ -130,12 +138,10 @@ $$
 Then we can compute $\hat{x}_t,d$ directly using the $d$th element of
 $\hat{\rho}(d)$
 
-$$
-\hat{x}_{t,d} = \hat{\rho}(d) \times \hat{x}_t
+\$\$ \hat{x}\_{t,d} = \hat{\rho}(d) \times \hat{x}\_t
 
-$$
-Here we multiply the expected total by the proportion expected at that
-particular delay $d$.
+\$\$ Here we multiply the expected total by the proportion expected at
+that particular delay $d$.
 
 ### Estimate of uncertainty in the nowcast
 

--- a/vignettes/model_definition.md
+++ b/vignettes/model_definition.md
@@ -1,0 +1,142 @@
+---
+title: "Mathematical description of `baselinenowcast` method"
+output: html_document
+---
+
+## `baselinenowcast` mathematical model
+
+The following describes the estimate of the delay distribution, the generation
+of the point nowcast, and the estimate of the observation error, for a
+partially observed or complete reporting triangle.
+The method assumes that the units of the delays, $d$$ and the units of
+reference time $t$ are the same, e.g. weekly data and weekly releases or
+daily data with daily releases.
+This method is based on the method described by (Wolffram et al. 2023)
+developed by the Karlsruhe Institute of Technology.
+
+### Notation
+
+We denote $X_{t,d}, d = 0, .., D$ as the number of cases occurring on time $t$
+which appear in the dataset with a delay of $d$.
+For example, a delay $d = 0$ means that a case occurring on day $t$ arrived
+in the dataset on day $t$, or on what is considered to be the first possible
+report date in practice.
+We only consider cases reporting within a maximum delay $D$.
+The number of cases reporting for time $t$ with a delay of at most $d$ can be
+written as:
+
+$$X_{t, \le d} = \sum_{i=0}^d X_{t,i} $$
+
+Such that $X_t = X{t, \le D}$ is the “final” number of reported cases on time $t$. Conversely, for $d < D$
+
+$$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
+
+is the number of cases still missing after $d$ delays.
+
+We refer to $X_t$ to describe a random variable, $x_t$ for the corresponding
+observation, and $\hat{x}_t$ for an estimated/imputed value.
+
+We refer to the matrix of $x$ available at a given data release time $t^*$,
+as the reporting triangle. Here, all $t+d > t^*$ have yet to be observed.
+
+* Need to fix alignment so this looks like a table.
+$$
+\begin{align}
+x_{1,1} \ x_{1,2} \ x_{1,3} \ ... \ x_{1, D-1} \ x_{1,D} \\
+x_{2,1} \ x_{2,2} \ x_{2,3} \ ... \ x_{2, D-1} \ x_{2,D} \\
+x_{3,1} \ x_{3,2} \ x_{3,3} \ ... \ x_{3, D-1} \ x_{3,D} \\
+x_{t^*-1, 1} \ x_{t^*-1, 2} \ x_{t^*-1, 3} \ ... \ x_{t^*-1, D-1}, x_{t^*-1, D} \\
+x_{t^*, 1} \ x_{t^*, 2} \ x_{t^*, 3} \ ... \ x_{t^*, D-1}, x_{t^*, D}
+\end{align}
+$$
+
+### Point estimate of the delay distribution
+We use the entire reporting triangle to compute an empirical estimate of the
+delay distribution, $\rho(d)$, or the probability that a case at reference time
+$t$ appears in the dataset at time $t + d$.
+We will refer to the realized empirical estimate of the delay distribution from a reporting triangle as $\hat{\rho}(d)$.
+
+The delay distribution, $\rho(d)$ can be estimated directly from the completed reporting matrix $X$
+$$
+{\rho}_d= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
+$$
+
+In the special case when the time the estimate is made $t'$, is beyond the data
+release time $t^{*}$, such that $t' \ge t^* + D$, $\hat{\rho}_d$ can be
+computed directly by summing over all reference time points $t$  at each
+delay $d$.
+
+In the case where there are partial observations, in order to properly weight
+the denominator with the missing delays, we have to first impute the cases
+$\hat{x}_{t,d}$ for all instances where $t+d > t^*$.
+This amounts to computing the point nowcast from the partial reporting triangle.
+
+### Point nowcast from incomplete reporting matrix
+
+To do so, we start by defining $\theta_d$, which is the factor by which the
+cases on delay $d$ compare to the total cases through delay $d-1$, which can be
+computed as:
+
+$$
+\hat{\theta}_d(t^*) = \frac{\sum_{t=1}^{t^*- d } x_{t, d}}{\sum_{d=1}^{d-1} \sum_{t=1}^{t^*-d} x_{t,d}}
+$$
+*Note this amounts to taking the sum of the elements in column $d$ up until time
+$t*-d$ and dividing by the sum over all the elements to the left of column $d$
+up until time $t*-d$, referred to as `block_top` and `block_top_left` in the
+code *
+
+This factor is then used to compute the expected values for all the missing
+rows with delay $d$ as:
+$$
+\hat{x}_{t,d} = \hat{\theta_d}(t^*) \times \sum_{t=t^*-d}^{t^*} x_{t,d-1}
+$$
+* Note this amounts to effectively taking the sum across the columns in the
+bottom left (`block_bottom_left` in the code) of the matrix up until column
+$d$ and multiplying by the factor to estimate the value of $x_{t,d}$ in
+each row. *
+
+This process is repeated iteratively, from left to right, to impute the bottom
+right triangle of the reporting matrix for each time $t$ and delay $d$ when
+$t+d>t^*$.
+The combination of the imputed and observed reporting matrix is then used to
+compute the delay distribution $\hat{\rho}(d)$ as described above.
+
+The factor, $\theta_d$ can only be computed for delays greater than 0, which
+effectively means that a row of the reporting triangle without any
+observations, can not be imputed as the process works iteratively.
+Therefore, the reporting matrix must have at least an entry (though it can be
+0) for $x_{t*,d=0}$ to compute a nowcast for $t^*$.
+We will describe the method for estimating nowcasts for zero-valued counts
+below.
+
+We can then use the delay distribution $\hat{\rho(d)}$ to compute directly
+a point nowcast, without the iterative imputation to complete the reporting
+triangle.
+
+
+### Point nowcast from delay distribution $\rho(d)$
+The point nowcast of an incomplete reporting triangle can be computed directly
+from the delay distribution, $\rho(d)$.
+
+We start by computing the expected total number of eventual observed cases
+$\hat{x}_t$, for each reference time $t$, by summing over all delays $d$ that
+have already been observed (up until $t*-t$) and dividing by the cumulative sum
+of the delay distribution
+
+$$
+\hat{x}_t= \frac{\sum_{d=1}^{d=t*-t} x_{t,d}}{\sum_{d=1}^{d=t*-t} \hat{\rho}(d)}
+$$
+
+Then we can compute $\hat{x}_t,d$ directly using the $d$th element of
+$\hat{\rho}(d)$
+
+$$
+\hat{x}_{t,d} = \hat{\rho}(d) \times \hat{x}_t
+
+$$
+Here we multiply the expected total by the proportion expected at that
+particular delay $d$.
+
+### Estimate of uncertainty in the nowcast
+
+*Filling in tomorrow*

--- a/vignettes/model_definition.md
+++ b/vignettes/model_definition.md
@@ -1,6 +1,6 @@
 # `baselinenowcast` mathematical model
 
-The following describes the estimate of the delay distribution, the generation of the point nowcast, and the estimate of the observation error, for a partially observed or complete reporting triangle. The method assumes that the units of the delays, $d$\$ and the units of reference time $t$ are the same, e.g. weekly data and weekly releases or daily data with daily releases. This method is based on the method described by (Wolffram et al. 2023) developed by the Karlsruhe Institute of Technology.
+The following describes the estimate of the delay distribution, the generation of the point nowcast, and the estimate of the observation error, for a partially observed or complete reporting triangle. The method assumes that the units of the delays, $d$\$ and the units of reference time $t$ are the same, e.g. weekly data and weekly releases or daily data with daily releases. This method is based on the method described by ([Wolffram et al. 2023](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1011394)) developed by the Karlsruhe Institute of Technology.
 
 ### Notation
 


### PR DESCRIPTION
## Description

This PR closes #35.

This is a write-up of the methods being implemented to:
- estimate a delay distribution 
    - from a complete reporting matrix
    - using imputation of the point nowcast 
- estimate a point nowcast from an incomplete reporting triangle and delay distribution
- estimate observation error in a nowcast from a complete or partially observed reporting triangle. 
    - iteratively and retrospectively re-estimate delay distribution and re-compute nowcasts, in order to simulate the out-of-sample predictive error that would have been made in the past 


Note @seabbs This could benefit from #34 to preview the new article but I am stuck on that 404 error (which I think is from the different website name than what is expected, but not sure since website is working fine in main) 


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [X] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
