### PR TITLE
Hot fix: don't assume R adds a V to column names

### DIFF
--- a/R/nowcast_list_to_df.R
+++ b/R/nowcast_list_to_df.R
@@ -94,7 +94,7 @@ convert_reporting_square_to_df <- function(matrix,
   df_long <- data.frame(
     time = rep(seq_len(nrow(df_wide)), each = ncol(df_wide)),
     delay = rep(seq_len(ncol(df_wide)), times = nrow(df_wide)),
-    count = as.vector(t(df_wide[, grep("^V", names(df_wide), value = TRUE)]))
+    count = as.vector(t(df_wide))
   )
 
   if (!is.null(draw)) {


### PR DESCRIPTION
## Description

This PR is a hot-fix, which no longer assume that R will add a V prefix to all column names when converting from a matrix to a data.frame. When prototyping these functions, it always did this but when applying to another example it didn't and in general this is more rigid than we'd want (we just want the elements of the original matrix as a long vector)



## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
