### PR TITLE
Issue 75 follow-up: fix error message suggestion

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -109,8 +109,8 @@
         "Value of delay PMF at delay = 0 is 0, and the latest reference time ",
         "in the reporting matrix only contains a value at delay = 0. There is",
         "insufficient information to generate a point nowcast for the latest ",
-        "reference time. Consider re-indexing to set the delay = 0 to the ",
-        "first delay where there are observations."
+        "reference time. Consider truncating to an earlier reference time to ",
+        "ensure a nowcast, not a forecast, is being produced."
       )
     )
   }


### PR DESCRIPTION
## Description

This PR is an add-on to #75, it modifies the error message to suggest that a nowcast be made from an earlier reference time rather than suggesting re-indexing, per @jbracher's suggestion. 

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
