### PR TITLE
Issue 97: Estimate dispersion by delay and reference time

### DIFF
--- a/R/add_uncertainty.R
+++ b/R/add_uncertainty.R
@@ -47,7 +47,8 @@ add_uncertainty <- function(point_nowcast_matrix,
 #' Get a probabilistic draw from the observation model
 #'
 #' The function ingests an estimate of a point nowcast, in the form of a
-#'   point nowcast matrix and a vector of dispersion parameters, and draws
+#'   point nowcast matrix and a vector of dispersion parameters corresponding to
+#'   the dispersion parameter for each delay, and draws
 #'   from a negative binomial to get a single expected observed probabilistic
 #'   draw of a nowcast
 #' @inheritParams add_uncertainty
@@ -104,13 +105,12 @@ get_nowcast_mat_draw <- function(point_nowcast_matrix,
   if (!is.matrix(point_nowcast_matrix)) {
     cli_abort(message = "`point_nowcast_matrix` is not a matrix.")
   }
-
+  max_t <- nrow(point_nowcast_matrix)
+  max_delay <- ncol(point_nowcast_matrix) - 1
   for (i in seq_along(disp)) {
-    max_t <- nrow(point_nowcast_matrix)
-    max_delay <- ncol(point_nowcast_matrix) - 1
-    # Apply to each row, starting from the bottom and moving up
-    mean_vals <- point_nowcast_matrix[(max_t - i + 1), (i:max_delay + 1)]
-    nowcast_w_obs_error[(max_t - i + 1), (i:max_delay + 1)] <- rnbinom(
+    # Apply to each column (delay), moving left to right
+    mean_vals <- point_nowcast_matrix[(max_t - i + 1):max_t, i + 1]
+    nowcast_w_obs_error[(max_t - i + 1):max_t, i + 1] <- rnbinom(
       n = length(mean_vals),
       size = disp[i],
       mu = mean_vals

--- a/R/add_uncertainty.R
+++ b/R/add_uncertainty.R
@@ -106,7 +106,6 @@ get_nowcast_mat_draw <- function(point_nowcast_matrix,
     cli_abort(message = "`point_nowcast_matrix` is not a matrix.")
   }
   max_t <- nrow(point_nowcast_matrix)
-  max_delay <- ncol(point_nowcast_matrix) - 1
   for (i in seq_along(disp)) {
     # Apply to each column (delay), moving left to right
     mean_vals <- point_nowcast_matrix[(max_t - i + 1):max_t, i + 1]

--- a/R/add_uncertainty.R
+++ b/R/add_uncertainty.R
@@ -107,9 +107,10 @@ get_nowcast_mat_draw <- function(point_nowcast_matrix,
 
   for (i in seq_along(disp)) {
     max_t <- nrow(point_nowcast_matrix)
-    # Start at second column, move left to right
-    mean_vals <- point_nowcast_matrix[(max_t - i + 1):max_t, i + 1]
-    nowcast_w_obs_error[(max_t - i + 1):max_t, i + 1] <- rnbinom(
+    max_delay <- ncol(point_nowcast_matrix) - 1
+    # Apply to each row, starting from the bottom and moving up
+    mean_vals <- point_nowcast_matrix[(max_t - i + 1), (i:max_delay + 1)]
+    nowcast_w_obs_error[(max_t - i + 1), (i:max_delay + 1)] <- rnbinom(
       n = length(mean_vals),
       size = disp[i],
       mu = mean_vals

--- a/R/estimate_dispersion.R
+++ b/R/estimate_dispersion.R
@@ -109,7 +109,6 @@ estimate_dispersion <- function(
   }
 
   max_delay <- ncol(list_of_ncs[[1]]) - 1
-  n_horizons <- ncol(list_of_ncs[[1]])
   for (i in seq_len(n)) {
     # Rretrospective nowcast as of i delays ago
     nowcast_i <- list_of_ncs[[i]]
@@ -145,9 +144,11 @@ estimate_dispersion <- function(
     )
   # Separate step which uses the dataframe that compares the expected values to
   # add and the values observed at each reference time and delay to estimate
-  # the dispersion as a function of reference time (horizon).
-  disp_params <- vector(length = max_delay + 1)
-  for (i in seq_len(max_delay + 1)) {
+  # the dispersion as a function of reference time. We intentionally only
+  # go back to the maximum delay though, so these are only estimated for the
+  # parts of the matrix that we've nowcasted
+  disp_params <- vector(length = max_delay)
+  for (i in 1:max_delay) {
     obs_temp <- df_exp_obs$obs_t_d[df_exp_obs$horizon == i]
     mu_temp <- df_exp_obs$mu_t_d[df_exp_obs$horizon == i] + 0.1
     disp_params[i] <- .fit_nb(x = obs_temp, mu = mu_temp)

--- a/R/estimate_dispersion.R
+++ b/R/estimate_dispersion.R
@@ -109,7 +109,6 @@ estimate_dispersion <- function(
   }
 
   max_delay <- ncol(list_of_ncs[[1]]) - 1
-  n_delays <- max_delay # We don't estimate a dispersion for delay =0
   n_ref_times <- nrow(list_of_ncs[[1]])
   for (i in seq_len(n)) {
     # Rretrospective nowcast as of i delays ago

--- a/man/estimate_dispersion.Rd
+++ b/man/estimate_dispersion.Rd
@@ -19,7 +19,8 @@ containing all observations as of the latest reference time. Elements of
 list are paired with elements of \code{pt_nowcast_mat_list}.}
 
 \item{n}{Integer indicating the number of reporting matrices to use to
-estimate the dispersion parameters.}
+estimate the dispersion parameters. Default is the number of matrices
+in the \code{pt_nowcast_mat_list}}
 }
 \value{
 Vector of length one less than the number of columns in the
@@ -30,7 +31,8 @@ of the dispersion parameter for each delay d, starting at delay d=1.
 This function ingests a list of point nowcast matrices and a corresponding
 list of truncated reporting matrices and uses both to estimate a
 vector of negative binomial dispersion parameters from the observations
-and estimates at each delay, starting at delay = 1.
+and estimates at each reference time up until the latest reference time
+minust the maximum delay (excluding the latest one).
 }
 \examples{
 triangle <- matrix(

--- a/man/estimate_dispersion.Rd
+++ b/man/estimate_dispersion.Rd
@@ -31,8 +31,8 @@ of the dispersion parameter for each delay d, starting at delay d=1.
 This function ingests a list of point nowcast matrices and a corresponding
 list of truncated reporting matrices and uses both to estimate a
 vector of negative binomial dispersion parameters from the observations
-and estimates at each reference time up until the latest reference time
-minust the maximum delay (excluding the latest one).
+and estimates at each delay starting at delay = 1 and up until the
+maximum delay.
 }
 \examples{
 triangle <- matrix(

--- a/man/get_nowcast_mat_draw.Rd
+++ b/man/get_nowcast_mat_draw.Rd
@@ -22,7 +22,8 @@ from \code{disp}
 }
 \description{
 The function ingests an estimate of a point nowcast, in the form of a
-point nowcast matrix and a vector of dispersion parameters, and draws
+point nowcast matrix and a vector of dispersion parameters corresponding to
+the dispersion parameter for each delay, and draws
 from a negative binomial to get a single expected observed probabilistic
 draw of a nowcast
 }

--- a/tests/testthat/test-estimate_dispersion.R
+++ b/tests/testthat/test-estimate_dispersion.R
@@ -88,7 +88,7 @@ test_that("Error conditions are properly handled", {
   # Invalid n values
   expect_error(estimate_dispersion(valid_nowcasts, valid_trunc_rts, n = -1))
   expect_error(estimate_dispersion(valid_nowcasts, valid_trunc_rts, n = 1.5))
-  expect_error(estimate_dispersion(valid_nowcasts, valid_trunc_rts, n = 3))
+  expect_error(estimate_dispersion(valid_nowcasts, valid_trunc_rts, n = 4))
 })
 
 ### Test 4: Edge Cases ---------------------------------------------------------
@@ -109,10 +109,7 @@ test_that("Matrix dimension validation works", {
     test_triangle[1:5, ],
     test_triangle[1:3, ]
   )
-  expect_error(
-    estimate_dispersion(valid_nowcasts, bad_trunc_rts),
-    "Dimensions of the first `n` matrices in `pt_nowcast_mat_list` and"
-  ) # nolint
+  expect_error(estimate_dispersion(valid_nowcasts, bad_trunc_rts)) # nolint
 })
 
 ## Test 6: fit_nb returns NA if nothing passed to it---------------------------

--- a/tests/testthat/test-estimate_dispersion.R
+++ b/tests/testthat/test-estimate_dispersion.R
@@ -118,3 +118,70 @@ test_that("Passing in empty vector returns NA", {
   NA_result <- .fit_nb(x, mu = 1)
   expect_true(is.na(NA_result))
 })
+
+
+## Test 7: Make dispersion as a function of delay dramatic and test fxn works--
+# Sample data setup
+test_triangle <- matrix(
+  c(
+    1, 2, 3,
+    1, 2, 9,
+    1, 2, 0,
+    1, 2, 5,
+    1, 2, NA,
+    1, NA, NA
+  ),
+  nrow = 6,
+  byrow = TRUE
+)
+
+nowcast1 <- matrix(
+  c(
+    1, 2, 3,
+    1, 2, 9,
+    1, 2, 0,
+    1, 2, 4,
+    1, 2, 4
+  ),
+  nrow = 5,
+  byrow = TRUE
+)
+nowcast2 <- matrix(
+  c(
+    1, 2, 3,
+    1, 2, 9,
+    1, 2, 6,
+    1, 2, 6
+  ),
+  nrow = 4,
+  byrow = TRUE
+)
+nowcast3 <- matrix(
+  c(
+    1, 2, 3,
+    1, 2, 3,
+    1, 2, 3
+  ),
+  nrow = 3,
+  byrow = TRUE
+)
+
+
+valid_nowcasts <- list(nowcast1, nowcast2, nowcast3)
+
+valid_trunc_rts <- list(
+  test_triangle[1:5, ],
+  test_triangle[1:4, ],
+  test_triangle[1:3, ]
+)
+
+result <- estimate_dispersion(
+  pt_nowcast_mat_list = valid_nowcasts,
+  trunc_rep_mat_list = valid_trunc_rts,
+  n = 3
+)
+
+test_that("First delay dispersion is high, second is low", {
+  expect_true(result[1] > 500) # low dispersion in delay = 1
+  expect_true(result[2] < 10) # high dispersion in delay = 2
+})

--- a/tests/testthat/test-estimate_dispersion.R
+++ b/tests/testthat/test-estimate_dispersion.R
@@ -68,7 +68,7 @@ test_that("Basic functionality with valid inputs", {
 ### Test 2: Default Parameter Handling -----------------------------------------
 test_that("Default n parameter works correctly", {
   result_default <- estimate_dispersion(valid_nowcasts, valid_trunc_rts)
-  result_explicit <- estimate_dispersion(valid_nowcasts, valid_trunc_rts, n = 2)
+  result_explicit <- estimate_dispersion(valid_nowcasts, valid_trunc_rts, n = 3)
   expect_identical(result_default, result_explicit)
 })
 

--- a/tests/testthat/test-estimate_dispersion.R
+++ b/tests/testthat/test-estimate_dispersion.R
@@ -17,7 +17,7 @@ nowcast1 <- matrix(
     10, 7, 1,
     15, 12, 2,
     14, 16, 3,
-    11, 21, 8,
+    11, 21, 8.1,
     10, 15.3, 3.5
   ),
   nrow = 5,
@@ -25,28 +25,38 @@ nowcast1 <- matrix(
 )
 nowcast2 <- matrix(
   c(
-    10, 7, 0.8,
-    15, 12, 2.0,
+    10, 7, 1,
+    15, 12, 2.3,
     14, 16, 2.5,
-    11, 25.5, 2
+    11, 25.5, 2.1
   ),
   nrow = 4,
   byrow = TRUE
 )
+nowcast3 <- matrix(
+  c(
+    10, 7, 1,
+    15, 12, 2.0,
+    14, 14.1, 1.9
+  ),
+  nrow = 3,
+  byrow = TRUE
+)
 
 
-valid_nowcasts <- list(nowcast1, nowcast2)
+valid_nowcasts <- list(nowcast1, nowcast2, nowcast3)
 
 valid_trunc_rts <- list(
   test_triangle[1:5, ],
-  test_triangle[1:4, ]
+  test_triangle[1:4, ],
+  test_triangle[1:3, ]
 )
 ### Test 1: Basic Functionality ------------------------------------------------
 test_that("Basic functionality with valid inputs", {
   result <- estimate_dispersion(
     pt_nowcast_mat_list = valid_nowcasts,
     trunc_rep_mat_list = valid_trunc_rts,
-    n = 2
+    n = 3
   )
 
   # Verify output structure

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -81,7 +81,8 @@ In the case where we have missing values in the bottom right (i.e. we have a rep
 
 The multiplicative model works by iteratively "filling in" the reporting triangle starting from the bottom left, and moving column by column from left to right until the bottom right of the triangle is filled in.
 
-![Visual description of the iterative “completing” of the reporting triangle, moving from left to right and bottom to top. In this cases, we are imputing \$x\_{t=6, d = 2}\$ and \$x\_{t=5, d= 2}\$ assuming that the ratio between \$x\_{t=1:4, d = 2}\$ (block top), and \$x\_{t=1:4, d=0:1}\$ (block top left) holds for for \$x\_{t=5:6, d = 2}\$ (block bottom) and \$x\_{t=5:6, d = 0:1}\$ (block bottom left). In this example, \$\\hat{x}\_{t=6, d = 1}\$ has already been imputed using the same approach, and we treat it as known going forward. This process is repeated across the reporting triangle to estimate all values outlined in the dashed lines.](../man/figures/schematic_fig.png){#fig1}
+![Visual description of the iterative “completing” of the reporting triangle, moving from left to right and bottom to top. In this cases, we are imputing $x_{t=6, d = 2}$ and $x_{t=5, d= 2}$ assuming that the ratio between $x_{t=1:4, d = 2}$ (block top), and $x_{t=1:4, d=0:1}$ (block top left) holds for for $x_{t=5:6, d = 2}$ (block bottom) and $x_{t=5:6, d = 0:1}$ (block bottom left). In this example, $\hat{x}_{t=6, d = 1}$ has already been imputed using the same approach, and we treat it as known going forward. This process is repeated across the reporting triangle to estimate all values outlined in the dashed lines.](../man/figures/schematic_fig.png){#fig1}
+
 
 The method requires at least one observation, at delay $d=0$ for the most recent reference time, located at the bottom left of the reporting triangle in Figure \@ref(fig1) above. The method assumes that the values at each delay $d$ for the recent times, $t$, will consist of the same proportion of the values previously reported for earlier times $t$. To fill in the missing values for each column $d$, we sum over the rectangle of completely observed reference times for all $d-1$ columns (block top left) and sum over the column of completely observed reference times for all of the entries in column $d$ (block left). The ratio of these two sums is assumed to be the same in the missing entries in column $d$, so we use the entries observed up to $d-1$ for each incomplete reference time (block bottom left), and scale by this ratio to get the missing entries in column $d$. This process is repeated for each delay from $d$ up to the maximum delay $D$. At each iteration an additional reference time entry is computed as the delay $d$ increases.
 
@@ -109,7 +110,7 @@ The `apply_delay()` function ingests a reporting triangle or an incomplete repor
 
 # Estimate of dispersion
 
-To estimate the uncertainty in the nowcasts, we use past nowcast errors and assume a negative binomial observation model.
+To estimate the uncertainty in the nowcasts, we use past nowcast errors in estimates of elements of the nowcast matrix for each reference time and delay, assuming a negative binomial observation model.
 
 ## Generation of retrospective reporting triangles
 
@@ -121,14 +122,15 @@ To generate the set of $M$ reporting triangles, we simply remove the last $m$ ro
 
 From the $M$ reporting triangles, we apply the method described above to estimate a delay distribution from a reporting triangle and generate a point nowcast for each reporting triangle, to generate $M$ point nowcasts. The function `generate_point_nowcasts()` ingests the list of reporting triangles, estimates a delay distribution for each, and generates a list of point nowcast matrices.
 
-## Fit point nowcast matrices and observed values to a negative binomial observation model at each delay
+## Fit point estimates and observed counts to a negative binomial observation model by delay
 
-We then take the list of point nowcast matrices, and the list of truncated incomplete reporting matrices (these do not necessarily contains NAs on the bottom right, the bottom right could be entirely or partially observed). For each delay $d$ we identify the overlapping set of matrix elements that were imputed retrospectively and matrix elements that had been observed as of the most recent time point.
+We then take the list of point nowcast matrices, and the list of truncated incomplete reporting matrices (these do not necessarily contains NAs on the bottom right, the bottom right could be entirely or partially observed).
+For each retrospective nowcast time $t= s^*$, we identify the overlapping set of matrix elements that were estimated and the matrix elements that had been observed as of the most recent time point.
 
-For each delay $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, >d}$ follow a negative binomial observation model with a mean of $\hat{x}_{s^*-d}$:
+For each delay $d = 1, ..., D$ we assume that the observed values in each element of the matrix, $X_{s^*-d, >d}$ follow a negative binomial observation model with a mean of $\hat{X}_{s^*-d, >d}$, for all $s^* = t^*, t^*-1, ... t^*-M$, with the negative binomial dispersion fit for each delay $d$ across all reference times $t$ and retrospective final reference times $s^*$ (Struggling to communicate this in mathematical notation that this is across $M$ $s^*$s).
 
 $$
-X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi_d)
+X_{s^*-d,>d} | \hat{X}_{s^*-d, >d}(s^*) \sim NegBin(\mu = \hat{X}_{s^*-d, >d}+ 0.1, \phi = \phi_d)
 $$
 
 We add a small number (0.1) to the mean to avoid an ill-defined negative binomial. We note that to perform all these computations, data snapshots from at least $N + M$ past observations, or rows of the original reporting triangle (or matrix), are needed. This estimate of the uncertainty accounts for the empirical uncertainty in the point estimate of the delay distribution over time.
@@ -137,10 +139,10 @@ The function `estimate_dispersion()` ingests a list of truncated reporting matri
 
 # Generate probabilistic nowcast matrices
 
-Using the dispersion parameters for each delay, $\phi(d),$ for $d = 1,...D$, we can generate probabilistic nowcast matrices by drawing samples from the negative binomial:
+Using the dispersion parameters for each delay, $\phi_d,$ for $d = 1,...D$, we can generate probabilistic nowcast matrices by drawing samples from the negative binomial:
 
 $$
-X_{t,d} \sim NegBin(\mu = \hat{x}_{t,d}, \phi = \phi(d))
+X_{t,d} \sim NegBin(\mu = \hat{X}_{t,d}, \phi = \phi_d
 $$
 
 We can sample for any number of draws, and then use the draws to compute any desired quantiles to summarize the outputs.

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -127,10 +127,10 @@ From the $M$ reporting triangles, we apply the method described above to estimat
 We then take the list of point nowcast matrices, and the list of truncated incomplete reporting matrices (these do not necessarily contains NAs on the bottom right, the bottom right could be entirely or partially observed).
 For each retrospective nowcast time $t= s^*$, we identify the overlapping set of matrix elements that were estimated and the matrix elements that had been observed as of the most recent time point.
 
-For each delay $d = 1, ..., D$ we assume that the observed values in each element of the matrix, $X_{s^*-d, >d}$ follow a negative binomial observation model with a mean of $\hat{X}_{s^*-d, >d}$, for all $s^* = t^*, t^*-1, ... t^*-M$, with the negative binomial dispersion fit for each delay $d$ across all reference times $t$ and retrospective final reference times $s^*$ (Struggling to communicate this in mathematical notation that this is across $M$ $s^*$s).
+For each delay $d = 1, ..., D$ we assume that the observed values in each element of the matrix, $X_{s^*-d, d}$ follow a negative binomial observation model with a mean of $\hat{X}_{s^*-d, d}$, for all $s^* = t^*, t^*-1, ... t^*-M$, with the negative binomial dispersion fit for each delay $d$ across all reference times $t$ and retrospective final reference times $s^*$ (Struggling to communicate this in mathematical notation that this is across $M$ $s^*$s).
 
 $$
-X_{s^*-d,>d} | \hat{X}_{s^*-d, >d}(s^*) \sim NegBin(\mu = \hat{X}_{s^*-d, >d}+ 0.1, \phi = \phi_d)
+X_{s^*-d, d} | \hat{X}_{s^*-d, d}(s^*) \sim NegBin(\mu = \hat{X}_{s^*-d, d}+ 0.1, \phi = \phi_d)
 $$
 
 We add a small number (0.1) to the mean to avoid an ill-defined negative binomial. We note that to perform all these computations, data snapshots from at least $N + M$ past observations, or rows of the original reporting triangle (or matrix), are needed. This estimate of the uncertainty accounts for the empirical uncertainty in the point estimate of the delay distribution over time.

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -67,10 +67,10 @@ We will use the following to abbreviations to shorten names in the code:
 
 ## Estimate of the delay distribution from a reporting matrix
 
-We can use a reporting matrix to compute an empirical estimate of the delay distribution, $\pi(d)$. The empirical delay distribution, $\pi(d)$ can be computed directly from the reporting matrix $X$
+We can use a reporting matrix to compute an empirical estimate of the delay distribution, $\pi(d)$. The empirical delay distribution, $\pi(d)$ can be computed directly from the reporting matrix $x_{t,d}$
 
 $$
-\pi(d)= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
+\pi(d)= \frac{\sum_{t=1}^{t=t^*} x_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} x_{t,d}}
 $$
 
 Where the numerator is the sum of all the observations across reference times $t$ for a particular delay $d$, and the denominator is the sum across all reference times $t$ and delays $d$.
@@ -127,10 +127,10 @@ From the $M$ reporting triangles, we apply the method described above to estimat
 We then take the list of point nowcast matrices, and the list of truncated incomplete reporting matrices (these do not necessarily contains NAs on the bottom right, the bottom right could be entirely or partially observed).
 For each retrospective nowcast time $t= s^*$, we identify the overlapping set of matrix elements that were estimated and the matrix elements that had been observed as of the most recent time point.
 
-For each delay $d = 1, ..., D$ we assume that the observed values in each element of the matrix, $X_{s^*-d, d}$ follow a negative binomial observation model with a mean of $\hat{X}_{s^*-d, d}$, for all $s^* = t^*, t^*-1, ... t^*-M$, with the negative binomial dispersion fit for each delay $d$ across all reference times $t$ and retrospective final reference times $s^*$ (Struggling to communicate this in mathematical notation that this is across $M$ $s^*$s).
+For each delay $d = 1, ..., D$ we assume that the observed values in each element of the matrix, $x_{s^*-d, d}$ follow a negative binomial observation model with a mean of $\hat{x}_{s^*-d, d}$, for all $s^* = t^*, t^*-1, ... t^*-M$, with the negative binomial dispersion fit for each delay $d$ across all reference times $t$ and retrospective final reference times $s^*$ (Struggling to communicate this in mathematical notation that this is across $M$ $s^*$s).
 
 $$
-X_{s^*-d, d} | \hat{X}_{s^*-d, d}(s^*) \sim NegBin(\mu = \hat{X}_{s^*-d, d}+ 0.1, \phi = \phi_d)
+x_{t, d} | \hat{x}_{t= s^*-d, d}(s^*) \sim NegBin(\mu = \hat{x}_{t = s^*-d, d}+ 0.1, \phi = \phi_d)
 $$
 
 We add a small number (0.1) to the mean to avoid an ill-defined negative binomial. We note that to perform all these computations, data snapshots from at least $N + M$ past observations, or rows of the original reporting triangle (or matrix), are needed. This estimate of the uncertainty accounts for the empirical uncertainty in the point estimate of the delay distribution over time.


### PR DESCRIPTION
## Description

This PR closes #97. It does the following:
- makes our code consistent so that we are estimating the dispersion using individual elements of the reporting matrix (comparing observations at specific delays and reference times to point nowcasts at those delays, reference times, and retrospective nowcast dates), and then estimating dispersion, as a function of delay $d$ across all the reference times ( ( ($s^*-d$) and retrospective nowcast times $s^*$. E.g.
```math
X_{t,>d} | \hat{X}_{t=s^*-d, >d}(s^*) \sim NegBin(\mu = \hat{X}_{t=s^*-d, >d}+ 0.1, \phi = \phi_d)
```
- changes the implementation to apply these dispersion estimates to individual elements in the nowcast matrix columnwise (by delay) 
- updates the math in the model definition to reflect this, see my comment about struggling to communicate that we are stacking retrospective nowcast dates $s^*$ and estimating dispersion across reference times and retrospective nowcast dates, for each delay.


Note that this implementation is a lot less dispersed than the KIT method. I am thinking that this has to do with the difference in implementation between assuming a negative binomial observation model in the matrix elements vs in the predicted aggregated counts yet to be observed, bc in the former, we end up summing negative binomial draws (but I had thought this would be accounted for by higher dispersion estimates in the individual elements of the matrix ).


This implementation:
![image](https://github.com/user-attachments/assets/18d48052-858c-4c5a-a29a-750eb3d78d24)
Previous implementation:
![image](https://github.com/user-attachments/assets/b13bd0fd-449d-43e6-9f7c-76fbdff4649b)
KIT method 
![image](https://github.com/user-attachments/assets/e2f8dbff-b749-4498-921b-4d6df852598c)




## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
