### PR TITLE
Issue 93: ragged reporting support

### DIFF
--- a/R/get_delay_estimate.R
+++ b/R/get_delay_estimate.R
@@ -41,9 +41,11 @@
 #'   n = 4
 #' )
 #' print(delay_pmf)
-get_delay_estimate <- function(reporting_triangle,
-                               max_delay = ncol(reporting_triangle) - 1,
-                               n = nrow(reporting_triangle)) {
+get_delay_estimate <- function(
+  reporting_triangle,
+  max_delay = ncol(reporting_triangle) - 1,
+  n = nrow(reporting_triangle)
+) {
   # Check that the input reporting triangle is formatted properly.
   .validate_triangle(
     triangle = reporting_triangle,
@@ -54,47 +56,136 @@ get_delay_estimate <- function(reporting_triangle,
   # Produce a warning if the bottom left of a reporting trianglei s all 0s.
   if (isTRUE(.check_zeros_bottom_right(reporting_triangle))) {
     cli_warn(
-      message =
-        c(
-          "All entries in bottom right are 0. Are these true observations ",
-          "with zero reports, or are these unobserved? If the latter, ",
-          "replace with NA using the `replace_bottom_right_with_NA()` ",
-          "function."
-        )
+      message = c(
+        "All entries in bottom right are 0. Are these true observations ",
+        "with zero reports, or are these unobserved? If the latter, ",
+        "replace with NA using the `replace_bottom_right_with_NA()` ",
+        "function."
+      )
     )
   }
-  # Filter the reporting_triangle down to nrow = n_history_delay + 1,
-  # ncol = max_delay #nolint
+
+  # Filter the reporting_triangle down to relevant rows and columns
+  trunc_triangle <- .prepare_triangle(reporting_triangle, max_delay, n)
+
+  # Fill in missing values in the triangle
+  expectation <- .fill_triangle(trunc_triangle)
+
+  # Calculate probability mass function from filled triangle
+  pmf <- .calculate_pmf(expectation)
+
+  return(pmf)
+}
+
+#' Prepare the triangle by truncating and handling negative values
+#'
+#' @param reporting_triangle The original reporting triangle
+#' @param max_delay Maximum delay to consider
+#' @param n Number of reference times to use
+#' @return Prepared reporting triangle
+#' @noRd
+.prepare_triangle <- function(reporting_triangle, max_delay, n) {
   nr0 <- nrow(reporting_triangle)
   trunc_triangle <- reporting_triangle[(nr0 - n + 1):nr0, 1:(max_delay + 1)]
   rep_tri <- .handle_neg_vals(trunc_triangle)
+  return(rep_tri)
+}
+
+#' Fill in missing values in the reporting triangle
+#'
+#' @param rep_tri Prepared reporting triangle
+#' @return Matrix with imputed values for missing entries
+#' @noRd
+.fill_triangle <- function(rep_tri) {
   n_delays <- ncol(rep_tri)
   n_dates <- nrow(rep_tri)
-  mult_factor <- vector(length = max_delay - 1)
   expectation <- rep_tri
+
   # Find the column to start filling in
   start_col <- which(colSums(is.na(rep_tri)) > 0)[1]
 
   # Only fill in reporting triangle if it is incomplete
   if (!is.na(start_col)) {
-    for (co in start_col:(n_delays)) {
-      block_top_left <- rep_tri[1:(n_dates - co + 1), 1:(co - 1), drop = FALSE]
-      block_top <- rep_tri[1:(n_dates - co + 1), co, drop = FALSE]
-      mult_factor[co - 1] <- sum(block_top) / max(sum(block_top_left), 1)
-      block_bottom_left <- expectation[(n_dates - co + 2):n_dates, 1:(co - 1),
-        drop = FALSE
-      ]
-      # We compute the expectation so that we can get the delay estimate
-      expectation[(n_dates - co + 2):n_dates, co] <- mult_factor[co - 1] *
-        rowSums(
-          block_bottom_left
-        )
+    for (co in start_col:n_delays) {
+      # Extract relevant blocks of the triangle
+      block_top_left <- .extract_block_top_left(rep_tri, co, n_dates)
+      block_top <- .extract_block_top(rep_tri, co, n_dates)
+
+      # Calculate multiplication factor
+      mult_factor <- .calculate_mult_factor(block_top, block_top_left)
+
+      # Extract block bottom left
+      block_bottom_left <- .extract_block_bottom_left(expectation, co, n_dates)
+
+      # Compute expectations for bottom right
+      expectation[(n_dates - co + 2):n_dates, co] <- .compute_expectations(
+        mult_factor,
+        block_bottom_left
+      )
     }
   }
 
+  return(expectation)
+}
 
-  # Use the completed reporting matrix to get the point estimate of the
-  # delay distribution
-  pmf <- colSums(expectation) / sum(expectation)
-  return(pmf)
+#' Extract the top left block of the triangle
+#'
+#' @param rep_tri Reporting triangle
+#' @param co Current column
+#' @param n_dates Number of dates
+#' @return Top left block of the triangle
+#' @noRd
+.extract_block_top_left <- function(rep_tri, co, n_dates) {
+  return(rep_tri[1:(n_dates - co + 1), 1:(co - 1), drop = FALSE])
+}
+
+#' Extract the top block of the triangle
+#'
+#' @param rep_tri Reporting triangle
+#' @param co Current column
+#' @param n_dates Number of dates
+#' @return Top block of the triangle
+#' @noRd
+.extract_block_top <- function(rep_tri, co, n_dates) {
+  return(rep_tri[1:(n_dates - co + 1), co, drop = FALSE])
+}
+
+#' Extract the bottom left block of the triangle
+#'
+#' @param expectation Expectation matrix
+#' @param co Current column
+#' @param n_dates Number of dates
+#' @return Bottom left block of the triangle
+#' @noRd
+.extract_block_bottom_left <- function(expectation, co, n_dates) {
+  return(expectation[(n_dates - co + 2):n_dates, 1:(co - 1), drop = FALSE])
+}
+
+#' Calculate multiplication factor
+#'
+#' @param block_top Top block
+#' @param block_top_left Top left block
+#' @return Multiplication factor
+#' @noRd
+.calculate_mult_factor <- function(block_top, block_top_left) {
+  sum(block_top) / max(sum(block_top_left), 1)
+}
+
+#' Compute expectations for the bottom right part
+#'
+#' @param mult_factor Multiplication factor
+#' @param block_bottom_left Bottom left block
+#' @return Vector of expectations
+#' @noRd
+.compute_expectations <- function(mult_factor, block_bottom_left) {
+  mult_factor * rowSums(block_bottom_left)
+}
+
+#' Calculate the probability mass function from the filled triangle
+#'
+#' @param expectation Filled triangle matrix
+#' @return Probability mass function
+#' @noRd
+.calculate_pmf <- function(expectation) {
+  colSums(expectation) / sum(expectation)
 }

--- a/R/get_delay_estimate.R
+++ b/R/get_delay_estimate.R
@@ -168,7 +168,7 @@ get_delay_estimate <- function(
 #' @return Multiplication factor
 #' @noRd
 .calculate_mult_factor <- function(block_top, block_top_left) {
-  sum(block_top) / max(sum(block_top_left), 1)
+  return(sum(block_top) / max(sum(block_top_left), 1))
 }
 
 #' Compute expectations for the bottom right part
@@ -178,7 +178,7 @@ get_delay_estimate <- function(
 #' @return Vector of expectations
 #' @noRd
 .compute_expectations <- function(mult_factor, block_bottom_left) {
-  mult_factor * rowSums(block_bottom_left)
+  return(mult_factor * rowSums(block_bottom_left))
 }
 
 #' Calculate the probability mass function from the filled triangle
@@ -187,5 +187,5 @@ get_delay_estimate <- function(
 #' @return Probability mass function
 #' @noRd
 .calculate_pmf <- function(expectation) {
-  colSums(expectation) / sum(expectation)
+  return(colSums(expectation) / sum(expectation))
 }

--- a/R/get_delay_estimate.R
+++ b/R/get_delay_estimate.R
@@ -107,18 +107,24 @@ get_delay_estimate <- function(
   # Only fill in reporting triangle if it is incomplete
   if (!is.na(start_col)) {
     for (co in start_col:n_delays) {
+      start_row <- which(is.na(rep_tri[, co]))[1]
       # Extract relevant blocks of the triangle
-      block_top_left <- .extract_block_top_left(rep_tri, co, n_dates)
-      block_top <- .extract_block_top(rep_tri, co, n_dates)
+      block_top_left <- .extract_block_top_left(rep_tri, co, n_dates, start_row)
+      block_top <- .extract_block_top(rep_tri, co, n_dates, start_row)
 
       # Calculate multiplication factor
       mult_factor <- .calculate_mult_factor(block_top, block_top_left)
 
       # Extract block bottom left
-      block_bottom_left <- .extract_block_bottom_left(expectation, co, n_dates)
+      block_bottom_left <- .extract_block_bottom_left(
+        expectation,
+        co,
+        n_dates,
+        start_row
+      )
 
       # Compute expectations for bottom right
-      expectation[(n_dates - co + 2):n_dates, co] <- .compute_expectations(
+      expectation[start_row:n_dates, co] <- .compute_expectations(
         mult_factor,
         block_bottom_left
       )
@@ -133,32 +139,31 @@ get_delay_estimate <- function(
 #' @param rep_tri Reporting triangle
 #' @param co Current column
 #' @param n_dates Number of dates
+#' @param start_row Starting row
 #' @return Top left block of the triangle
 #' @noRd
-.extract_block_top_left <- function(rep_tri, co, n_dates) {
-  return(rep_tri[1:(n_dates - co + 1), 1:(co - 1), drop = FALSE])
+.extract_block_top_left <- function(rep_tri, co, n_dates, start_row) {
+  return(rep_tri[1:(start_row - 1), 1:(co - 1), drop = FALSE])
 }
 
 #' Extract the top block of the triangle
 #'
-#' @param rep_tri Reporting triangle
-#' @param co Current column
-#' @param n_dates Number of dates
+#' @inheritParams .extract_block_top_left
 #' @return Top block of the triangle
 #' @noRd
-.extract_block_top <- function(rep_tri, co, n_dates) {
-  return(rep_tri[1:(n_dates - co + 1), co, drop = FALSE])
+.extract_block_top <- function(rep_tri, co, n_dates, start_row) {
+  return(rep_tri[1:(start_row - 1), co, drop = FALSE])
 }
 
 #' Extract the bottom left block of the triangle
 #'
 #' @param expectation Expectation matrix
 #' @param co Current column
-#' @param n_dates Number of dates
+#' @inheritParams .extract_block_top_left
 #' @return Bottom left block of the triangle
 #' @noRd
-.extract_block_bottom_left <- function(expectation, co, n_dates) {
-  return(expectation[(n_dates - co + 2):n_dates, 1:(co - 1), drop = FALSE])
+.extract_block_bottom_left <- function(expectation, co, n_dates, start_row) {
+  return(expectation[start_row:n_dates, 1:(co - 1), drop = FALSE])
 }
 
 #' Calculate multiplication factor

--- a/R/get_delay_estimate.R
+++ b/R/get_delay_estimate.R
@@ -11,6 +11,8 @@
 #' @param reporting_triangle Matrix of the reporting triangle, with rows
 #'   representing the time points of reference and columns representing the
 #'   delays. Can be a reporting matrix or incomplete reporting matrix.
+#'    Can also be a ragged reporting triangle, where multiple columns are
+#'    reported for the same row. (e.g. weekly reporting of daily data).
 #' @param max_delay Integer indicating the maximum delay to estimate, in units
 #'   of the delay. The default is to use the whole reporting triangle,
 #'   `ncol(triangle) -1`.

--- a/R/validate.R
+++ b/R/validate.R
@@ -8,9 +8,11 @@
 #' @inheritParams get_delay_estimate
 #' @returns NULL, invisibly
 #' @keywords internal
-.validate_triangle <- function(triangle,
-                               max_delay = ncol(triangle) - 1,
-                               n = nrow(triangle)) {
+.validate_triangle <- function(
+  triangle,
+  max_delay = ncol(triangle) - 1,
+  n = nrow(triangle)
+) {
   # Make sure the input triangle only contains integer values
   # and is of the correct class
   assert_class(triangle, "matrix")
@@ -19,10 +21,25 @@
   assert_integerish(n)
   assert_matrix(triangle, all.missing = FALSE)
 
-  if (nrow(triangle) <= ncol(triangle)) {
+  # Check if the triangle has a valid structure
+  # Ensure each column has at least one non-NA value
+  if (any(colSums(!is.na(triangle)) == 0)) {
     cli_abort(
-      message =
-        "Number of observations(rows) must be greater than the number of columns." # nolint
+      message = c(
+        "Invalid reporting triangle structure. Each column must have",
+        "at least one non-NA value."
+      )
+    )
+  }
+
+  # For ragged triangles (e.g. weekly reporting of daily data),
+  # we need to ensure the triangle has proper structure
+  if (!.check_na_bottom_right(triangle)) {
+    cli_abort(
+      message = c(
+        "Invalid reporting triangle structure. NA values should only",
+        "appear in the bottom right portion of the triangle."
+      )
     )
   }
 
@@ -79,15 +96,13 @@
 #' @importFrom cli cli_abort
 #' @returns NULL, invisibly
 #' @keywords internal
-.validate_delay_and_triangle <- function(triangle,
-                                         delay_pmf) {
+.validate_delay_and_triangle <- function(triangle, delay_pmf) {
   # Check that the input triangle only contains integer values
   assert_integerish(triangle)
   # Check that the inputs are the correct type
   assert_class(triangle, "matrix")
   assert_class(delay_pmf, "numeric")
   assert_matrix(triangle, all.missing = FALSE)
-
 
   # Make sure the triangle has the same number of columns as the delay
   if ((ncol(triangle) != length(delay_pmf))) {

--- a/tests/testthat/test-get_delay_estimate.R
+++ b/tests/testthat/test-get_delay_estimate.R
@@ -10,24 +10,17 @@ test_that("get_delay_estimate function works correctly", {
   expect_equal(sum(result), 1, tolerance = 1e-6)
 
   # Test 2: Custom max_delay
-  result_max_delay <- get_delay_estimate(triangle,
-    max_delay = 3
-  )
+  result_max_delay <- get_delay_estimate(triangle, max_delay = 3)
   expect_identical(as.integer(length(result_max_delay)), 4L)
 
   # Test 3: Custom n_history
-  result_n_history <- get_delay_estimate(triangle,
-    n = 20
-  )
+  result_n_history <- get_delay_estimate(triangle, n = 20)
   expect_is(result_n_history, "numeric")
 
   # Test 4: Input validation *These should be more useful error messages*
   expect_error(get_delay_estimate(triangle, max_delay = 0))
   expect_error(get_delay_estimate(triangle, n = 0))
-  expect_error(get_delay_estimate(triangle,
-    max_delay = 10,
-    n = 40
-  ))
+  expect_error(get_delay_estimate(triangle, max_delay = 10, n = 40))
 
   # Test 5: Errors when NAs are in upper part of reportign triangle
   # (These should be 0s)
@@ -49,11 +42,26 @@ test_that("get_delay_estimate handles partially complete reporting triangles", {
   # Test 8: Test that a partial triangle works correctly
   partial_triangle <- matrix(
     c(
-      80, 50, 25, 10,
-      100, 50, 30, 20,
-      90, 45, 25, 20,
-      80, 40, 15, NA,
-      70, 30, NA, NA
+      80,
+      50,
+      25,
+      10,
+      100,
+      50,
+      30,
+      20,
+      90,
+      45,
+      25,
+      20,
+      80,
+      40,
+      15,
+      NA,
+      70,
+      30,
+      NA,
+      NA
     ),
     nrow = 5,
     byrow = TRUE
@@ -67,11 +75,26 @@ test_that("get_delay_estimate handles partially complete reporting triangles", {
   # Test 9: Test that you get the correct delay with a complete triangle
   complete_triangle <- matrix(
     c(
-      80, 50, 25, 10,
-      100, 50, 30, 20,
-      90, 45, 25, 20,
-      80, 40, 15, 5,
-      70, 30, 10, 10
+      80,
+      50,
+      25,
+      10,
+      100,
+      50,
+      30,
+      20,
+      90,
+      45,
+      25,
+      20,
+      80,
+      40,
+      15,
+      5,
+      70,
+      30,
+      10,
+      10
     ),
     nrow = 5,
     byrow = TRUE
@@ -87,11 +110,26 @@ test_that("get_delay_estimate handles partially complete reporting triangles", {
   # Test 10: Test that you get a warning with zeros in the bottom right
   zero_triangle <- matrix(
     c(
-      80, 50, 25, 10,
-      100, 50, 30, 20,
-      90, 45, 25, 0,
-      80, 40, 0, 0,
-      70, 0, 0, 0
+      80,
+      50,
+      25,
+      10,
+      100,
+      50,
+      30,
+      20,
+      90,
+      45,
+      25,
+      0,
+      80,
+      40,
+      0,
+      0,
+      70,
+      0,
+      0,
+      0
     ),
     nrow = 5,
     byrow = TRUE
@@ -106,11 +144,26 @@ test_that("get_delay_estimate handles partially complete reporting triangles", {
   # Test 11: zeros not just on bottom right
   zero_triangle2 <- matrix(
     c(
-      80, 50, 25, 10,
-      100, 0, 30, 20,
-      90, 45, 25, 0,
-      80, 40, 0, 0,
-      70, 0, 0, 0
+      80,
+      50,
+      25,
+      10,
+      100,
+      0,
+      30,
+      20,
+      90,
+      45,
+      25,
+      0,
+      80,
+      40,
+      0,
+      0,
+      70,
+      0,
+      0,
+      0
     ),
     nrow = 5,
     byrow = TRUE
@@ -121,4 +174,76 @@ test_that("get_delay_estimate handles partially complete reporting triangles", {
     max_delay = 3,
     n = 5
   ))
+})
+
+test_that("get_delay_estimate works with weekly reporting of daily data", {
+  sim_delay_pmf <- c(0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.1)
+
+  counts <- c(100, 20, 30, 40, 50, 60, 70)
+
+  complete_triangle <- lapply(counts, function(x) x * sim_delay_pmf)
+  complete_triangle <- do.call(rbind, complete_triangle)
+
+  reporting_triangle <- matrix(
+    c(
+      10,
+      20,
+      30,
+      10,
+      10,
+      10,
+      10,
+      2,
+      4,
+      6,
+      2,
+      2,
+      2,
+      2,
+      3,
+      6,
+      9,
+      3,
+      3,
+      3,
+      3,
+      4,
+      8,
+      12,
+      4,
+      4,
+      4,
+      4,
+      5,
+      10,
+      15,
+      5,
+      5,
+      5,
+      NA,
+      6,
+      12,
+      18,
+      6,
+      NA,
+      NA,
+      NA,
+      7,
+      14,
+      NA,
+      NA,
+      NA,
+      NA,
+      NA
+    ),
+    nrow = 7,
+    byrow = TRUE
+  )
+
+  # Get delay estimate
+  delay_pmf <- get_delay_estimate(
+    reporting_triangle = reporting_triangle
+  )
+  # Test that the function returns the expected PMF
+  expect_identical(delay_pmf, sim_delay_pmf)
 })


### PR DESCRIPTION
<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This draft PR closes #93.

It refactors `get_delay_estimates` and adds support for ragged daily reporting by dropping the assumed relationship between rows and columns and instead using NAs to fix row locations.

It leads to knock on findings: 

- .validate_triangles is overly restricted and doesn't supported ragged daily reporting
- Support is also needed everywhere that reporting is constructed (i.e replace NA blah blah). I think that this can be simpler than the adaptive approach used here i.e with an index.
- anywhere that iterative multiplication support is used this needs to be ported. We can do this using our new internal functions.

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
