### PR TITLE
Issue 109: nomenclature adjustment

### DIFF
--- a/R/estimate_dispersion.R
+++ b/R/estimate_dispersion.R
@@ -8,7 +8,7 @@
 #'
 #' @param pt_nowcast_mat_list List of point nowcast matrices where rows
 #'    represent reference time points and columns represent delays.
-#' @param trunc_rep_mat_list List of truncated reporting matrices,
+#' @param trunc_rep_tri_list List of truncated reporting matrices,
 #'    containing all observations as of the latest reference time. Elements of
 #'    list are paired with elements of `pt_nowcast_mat_list`.
 #' @param n Integer indicating the number of reporting matrices to use to
@@ -40,13 +40,13 @@
 #' retro_nowcasts <- generate_pt_nowcast_mat_list(retro_rts, n = 5)
 #' disp_params <- estimate_dispersion(
 #'   pt_nowcast_mat_list = retro_nowcasts,
-#'   trunc_rep_mat_list = trunc_rts,
+#'   trunc_rep_tri_list = trunc_rts,
 #'   n = 2
 #' )
 #' disp_params
 estimate_dispersion <- function(
     pt_nowcast_mat_list,
-    trunc_rep_mat_list,
+    trunc_rep_tri_list,
     n = length(pt_nowcast_mat_list)) {
   # Check that the length of the list of nowcasts is greater than
   # or equal to the specified n
@@ -57,9 +57,9 @@ estimate_dispersion <- function(
       "estimation"
     ))
   }
-  if (length(trunc_rep_mat_list) < n) {
+  if (length(trunc_rep_tri_list) < n) {
     cli_abort(message = c(
-      "Insufficient elements in `trunc_rep_mat_list` for the `n` desired ",
+      "Insufficient elements in `trunc_rep_tri_list` for the `n` desired ",
       "number of observed reporting triangles specified for dispersion ",
       "estimation"
     ))
@@ -67,15 +67,15 @@ estimate_dispersion <- function(
   if (length(pt_nowcast_mat_list) < 1) {
     "`pt_nowcast_mat_list` is an empty list"
   }
-  if (length(trunc_rep_mat_list) < 1) {
-    "`trunc_rep_mat_list` is an empty list"
+  if (length(trunc_rep_tri_list) < 1) {
+    "`trunc_rep_tri_list` is an empty list"
   }
 
   assert_integerish(n, lower = 0)
 
   # Truncate to only n nowcasts
   list_of_ncs <- pt_nowcast_mat_list[1:n]
-  list_of_obs <- trunc_rep_mat_list[1:n]
+  list_of_obs <- trunc_rep_tri_list[1:n]
 
   # Check that nowcasts has no NAs, trunc_rts has some NAs
   if (any(sapply(list_of_ncs, anyNA))) {
@@ -87,7 +87,7 @@ estimate_dispersion <- function(
   if (!any(sapply(list_of_obs, anyNA))) {
     cli_abort(
       message =
-        "`trunc_rep_mat_list` does not contain any NAs"
+        "`trunc_rep_tri_list` does not contain any NAs"
     )
   }
   # Check that the sets of matrices are the same dimensions
@@ -97,7 +97,7 @@ estimate_dispersion <- function(
   if (!all_identical) {
     cli_abort(message = c(
       "Dimensions of the first `n` matrices in `pt_nowcast_mat_list` and ",
-      "`trunc_rep_mat_list` are not the same."
+      "`trunc_rep_tri_list` are not the same."
     ))
   }
 

--- a/R/truncate_triangles.R
+++ b/R/truncate_triangles.R
@@ -50,7 +50,7 @@ truncate_triangles <- function(reporting_triangle,
 
   results <- lapply(seq_len(n),
     truncate_triangle,
-    matr_observed = reporting_triangle
+    rep_tri = reporting_triangle
   )
 
   return(results)
@@ -88,11 +88,11 @@ truncate_triangles <- function(reporting_triangle,
 #'   byrow = TRUE
 #' )
 #'
-#' trunc_rep_tri <- truncate_triangle(t = 1, matr_observed = triangle)
+#' trunc_rep_tri <- truncate_triangle(t = 1, rep_tri = triangle)
 #' trunc_rep_tri
 truncate_triangle <- function(t,
-                              matr_observed) {
-  n_obs <- nrow(matr_observed)
+                              rep_tri) {
+  n_obs <- nrow(rep_tri)
   if (t >= n_obs) {
     cli_abort(
       message = c(
@@ -102,9 +102,9 @@ truncate_triangle <- function(t,
     )
   }
   assert_integerish(t, lower = 0)
-  matr_observed_trunc <- matrix(
-    matr_observed[1:(n_obs - t), ],
+  rep_tri_trunc <- matrix(
+    rep_tri[1:(n_obs - t), ],
     nrow = (n_obs - t)
   )
-  return(matr_observed_trunc)
+  return(rep_tri_trunc)
 }

--- a/R/truncate_triangles.R
+++ b/R/truncate_triangles.R
@@ -63,12 +63,12 @@ truncate_triangles <- function(reporting_triangle,
 #'
 #' @param t Integer indicating the number of timepoints to truncate off the
 #'   bottom of the original reporting triangle.
-#' @param matr_observed Matrix of the reporting triangle/matrix
+#' @param rep_tri Matrix of the reporting triangle/matrix
 #'   to be used to generate retrospective nowcast matrices, with rows
 #'   representing the time points of reference and columns representing the
 #'   delays.
 #'
-#' @returns Matrix with `t` fewer rows than `matr_observed`.
+#' @returns Matrix with `t` fewer rows than `rep_tri`.
 #' @importFrom checkmate assert_integerish
 #' @importFrom cli cli_abort
 #' @export

--- a/man/estimate_dispersion.Rd
+++ b/man/estimate_dispersion.Rd
@@ -6,7 +6,7 @@
 \usage{
 estimate_dispersion(
   pt_nowcast_mat_list,
-  trunc_rep_mat_list,
+  trunc_rep_tri_list,
   n = length(pt_nowcast_mat_list)
 )
 }
@@ -14,7 +14,7 @@ estimate_dispersion(
 \item{pt_nowcast_mat_list}{List of point nowcast matrices where rows
 represent reference time points and columns represent delays.}
 
-\item{trunc_rep_mat_list}{List of truncated reporting matrices,
+\item{trunc_rep_tri_list}{List of truncated reporting matrices,
 containing all observations as of the latest reference time. Elements of
 list are paired with elements of \code{pt_nowcast_mat_list}.}
 
@@ -54,7 +54,7 @@ retro_rts <- generate_triangles(trunc_rts)
 retro_nowcasts <- generate_pt_nowcast_mat_list(retro_rts, n = 5)
 disp_params <- estimate_dispersion(
   pt_nowcast_mat_list = retro_nowcasts,
-  trunc_rep_mat_list = trunc_rts,
+  trunc_rep_tri_list = trunc_rts,
   n = 2
 )
 disp_params

--- a/man/truncate_triangle.Rd
+++ b/man/truncate_triangle.Rd
@@ -4,7 +4,7 @@
 \alias{truncate_triangle}
 \title{Get a single truncated triangle}
 \usage{
-truncate_triangle(t, matr_observed)
+truncate_triangle(t, rep_tri)
 }
 \arguments{
 \item{t}{Integer indicating the number of timepoints to truncate off the
@@ -38,6 +38,6 @@ triangle <- matrix(
   byrow = TRUE
 )
 
-trunc_rep_tri <- truncate_triangle(t = 1, matr_observed = triangle)
+trunc_rep_tri <- truncate_triangle(t = 1, rep_tri = triangle)
 trunc_rep_tri
 }

--- a/man/truncate_triangle.Rd
+++ b/man/truncate_triangle.Rd
@@ -10,13 +10,13 @@ truncate_triangle(t, rep_tri)
 \item{t}{Integer indicating the number of timepoints to truncate off the
 bottom of the original reporting triangle.}
 
-\item{matr_observed}{Matrix of the reporting triangle/matrix
+\item{rep_tri}{Matrix of the reporting triangle/matrix
 to be used to generate retrospective nowcast matrices, with rows
 representing the time points of reference and columns representing the
 delays.}
 }
 \value{
-Matrix with \code{t} fewer rows than \code{matr_observed}.
+Matrix with \code{t} fewer rows than \code{rep_tri}.
 }
 \description{
 This function takes in a integer \code{t} and a reporting triangle and generates

--- a/tests/testthat/test-estimate_dispersion.R
+++ b/tests/testthat/test-estimate_dispersion.R
@@ -45,7 +45,7 @@ valid_trunc_rts <- list(
 test_that("Basic functionality with valid inputs", {
   result <- estimate_dispersion(
     pt_nowcast_mat_list = valid_nowcasts,
-    trunc_rep_mat_list = valid_trunc_rts,
+    trunc_rep_tri_list = valid_trunc_rts,
     n = 2
   )
 

--- a/tests/testthat/test-truncate_triangle.R
+++ b/tests/testthat/test-truncate_triangle.R
@@ -1,5 +1,5 @@
 # Example matrix for testing
-matr_observed <- matrix(
+rep_tri <- matrix(
   c(
     10, 20, 30,
     40, 50, NA,
@@ -13,7 +13,7 @@ matr_observed <- matrix(
 # Test 1: Basic functionality
 test_that("truncate_triangle works with positive t", {
   t <- 1
-  result <- truncate_triangle(t, matr_observed)
+  result <- truncate_triangle(t, rep_tri)
   expected <- matrix(
     c(
       10, 20, 30,
@@ -26,11 +26,11 @@ test_that("truncate_triangle works with positive t", {
   expect_identical(result, expected)
 })
 
-# Test 2: Edge case with t equal to nrow(matr_observed) fails
+# Test 2: Edge case with t equal to nrow(rep_tri) fails
 test_that("truncate_triangle throws an error when t is too large", {
-  t <- nrow(matr_observed)
+  t <- nrow(rep_tri)
   expect_error(
-    truncate_triangle(t, matr_observed),
+    truncate_triangle(t, rep_tri),
     "The as of time point is greater than or equal to the number of"
   )
 })
@@ -39,21 +39,21 @@ test_that("truncate_triangle throws an error when t is too large", {
 test_that("truncate_triangle throws an error for a negative t", {
   t <- -1
   expect_error(
-    truncate_triangle(t, matr_observed)
+    truncate_triangle(t, rep_tri)
   )
 })
 
 # Test 4: Non-integer t
 test_that("truncate_triangle throws an error for a non-integer t", {
   t <- 1.5
-  expect_error(truncate_triangle(t, matr_observed))
+  expect_error(truncate_triangle(t, rep_tri))
 })
 
 # Test 5: Zero t
 test_that("truncate_triangle handles zero t", {
   t <- 0L
-  result <- truncate_triangle(t, matr_observed)
-  expect_identical(result, matr_observed)
+  result <- truncate_triangle(t, rep_tri)
+  expect_identical(result, rep_tri)
 })
 
 # Test 6: Empty matrix input throws an error

--- a/vignettes/baselinenowcast.Rmd
+++ b/vignettes/baselinenowcast.Rmd
@@ -394,7 +394,7 @@ are needed to generate a nowcast of reporting triangle with 41 delay columns.
 
 ```{r generate-triangles}
 trunc_rep_tri_list <- truncate_triangles(reporting_triangle)
-retro_rep_tri_list <- generate_triangles(trunc_rep_mat_list)
+retro_rep_tri_list <- generate_triangles(trunc_rep_tri_list)
 ```
 The `generate_triangles()` function returns a list of
 reporting triangles, in order from the most to least

--- a/vignettes/baselinenowcast.Rmd
+++ b/vignettes/baselinenowcast.Rmd
@@ -393,7 +393,7 @@ are needed to generate a nowcast of reporting triangle with 41 delay columns.
 
 
 ```{r generate-triangles}
-trunc_rep_mat_list <- truncate_triangles(reporting_triangle)
+trunc_rep_tri_list <- truncate_triangles(reporting_triangle)
 retro_rep_tri_list <- generate_triangles(trunc_rep_mat_list)
 ```
 The `generate_triangles()` function returns a list of
@@ -420,7 +420,7 @@ the uncertainty at each horizon, starting at horizon 0.
 ```{r estimate-dispersion}
 disp_params <- estimate_dispersion(
   pt_nowcast_mat_list = retro_pt_nowcast_mat_list,
-  trunc_rep_mat_list = trunc_rep_mat_list
+  trunc_rep_tri_list = trunc_rep_tri_list
 )
 ```
 

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -33,7 +33,7 @@ $$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
 is the number of cases still missing after $d$ delay. We refer to $X_t$ to describe a random variable, $x_t$ for the corresponding observation, and $\hat{x}_t$ for an estimated/imputed value. The matrix of $x_{t,d}$ available at a given time $t^*$ is referred to as a reporting matrix. In the case where all $t+d>t^*$ have yet to be observed (e.g. $t^*$ is the current time), this reporting matrix is referred to as the reporting triangle, with all values in the bottom right corner of the triangle being missing, except for the first entry at $x_{t=t*, d = 0}$.
 
 |   | $d = 0$ | $d = 1$ | $d=2$ | $...$ | $d= D-1$ | $d= D$ |
-|----|----|----|----|----|----|----|
+|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
 | $t=1$ | $x_{1,0}$ | $x_{1,1}$ | $x_{1,2}$ | $...$ | $x_{1,D-1}$ | $x_{1, D}$ |
 | $t=2$ | $x_{2,0}$ | $x_{2,1}$ | $x_{2,2}$ | $...$ | $x_{2,D-1}$ | $x_{2, D}$ |
 | $t=3$ | $x_{3,0}$ | $x_{3,1}$ | $x_{3,2}$ | $...$ | $x_{3,D-1}$ | $x_{3, D}$ |
@@ -44,13 +44,15 @@ is the number of cases still missing after $d$ delay. We refer to $X_t$ to descr
 Throughout this document and package, we will refer to these matrices, as well as their corresponding vectors, using the following table. In this table, "point" refers to a point estimate. When not indicated, we are referring to a probabilistic draw from an observation model.
 
 | **Data Structure** | **Observations Only** | **Mixed (Obs + Predictions)** | **Pure Predictions Only** |
-|----|----|----|----|
-| **Matrix Format** | `reporting_matrix` (complete)<br>`reporting_triangle` (incomplete)<br>`incomplete_reporting_matrix` | `point_nowcast_matrix`<br>`nowcast_matrix` | `point_pred_matrix`<br>`pred_matrix` |
-| **List Format** | `reporting_matrix_list` (complete)<br>`reporting_triangle_list` (incomplete)<br>`incomplete_reporting_matrix_list` | `nowcast_matrix_list` | `pred_matrix_list` |
-| **Vector Format** | `observed_cases` | `point_nowcast`<br>`nowcast` | `point_pred`<br>`pred` |
+|------------------|------------------|------------------|------------------|
+| **Matrix Format** | `reporting_matrix` (complete with observations)<br>`reporting_triangle` (contains NAs for missing observations) | `point_nowcast_matrix`<br>`nowcast_matrix` | `point_pred_matrix`<br>`pred_matrix`  (contains NAs in elements where there were observations) |
+| **List Format** | `reporting_matrix_list` (complete)<br>`reporting_triangle_list` (contains NAs for missing observations) | `nowcast_matrix_list` | `pred_matrix_list` |
+| **Vector Format (summed across delays)** | `observed_cases` | `point_nowcast`<br>`nowcast` | `point_pred`<br>`pred` |
 | **DataFrame Format** | \- | `nowcast_df` | `pred_df` |
 
 For example, we refer to the matrix with imputed point estimates for all $t+d>t^*$ as a point nowcast matrix, a matrix with a complete set of observations for all elements as a reporting matrix, and a matrix with only the predictions as a point prediction matrix.
+
+In package documentation, we will generally use a reporting triangle to refer to a diagonal reporting triangle, which is the special case of a reporting triangle where the reporting delays and reference times are indexed on the same scale. An example of a diagonal reporting triangle is one with daily reporting of daily data. The package also supports what we refer to as a ragged reporting triangle, an example of which would be daily reporting of data referenced only once per week.
 
 We will use the following to abbreviations to shorten names in the code:
 
@@ -82,10 +84,10 @@ In the case where we have missing values in the bottom right (i.e. we have a rep
 The multiplicative model works by iteratively "filling in" the reporting triangle starting from the bottom left, and moving column by column from left to right until the bottom right of the triangle is filled in.
 
 ```{r squares}
-#nolint start
+# nolint start
 #| echo = FALSE,
 #| fig.cap = 'Visual description of the iterative “completing” of the reporting triangle, moving from left to right and bottom to top. In this cases, we are imputing $x_{t=6, d = 2}$ and $x_{t=5, d= 2}$ assuming that the ratio between $x_{t=1:4, d = 2}$ (block top), and $x_{t=1:4, d=0:1}$ (block top left) holds for for $x_{t=5:6, d = 2}$ (block bottom) and $x_{t=5:6, d = 0:1}$ (block bottom left). In this example, $\\hat{x}_{t=6, d = 1}$ has already been imputed using the same approach, and we treat it as known going forward. This process is repeated across the reporting triangle to estimate all values outlined in the dashed lines.'
-#nolint end
+# nolint end
 knitr::include_graphics(file.path("..", "man", "figures", "schematic_fig.png"))
 ```
 


### PR DESCRIPTION
## Description

This PR closes #109. 
What it does:
- removes nomenclature for an "incomplete reporting matrix" and just distinguished between a reporting matrix (all observations) and a reporting triangle (which contains NAs). This is edited in the `model_definition.Rmd` function. 
- Any function that can handle NAs will have an input as a reporting triangle, even if we can pass a reporting matrix. 


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [X] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
