### PR TITLE
Issue 132: fix caption

### DIFF
--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -86,14 +86,14 @@ The multiplicative model works by iteratively "filling in" the reporting triangl
 ```{r squares}
 #| echo = FALSE,
 #| fig.cap = 'Visual description of the iterative “completing” of the reporting
-#| triangle, moving from left to right and bottom to top. In this cases, we are
-#| imputing $x_{t=6, d = 2}$ and $x_{t=5, d= 2}$ assuming that the ratio
-#| between $x_{t=1:4, d = 2}$ (block top), and $x_{t=1:4, d=0:1}$
-#| (block top left) holds for for $x_{t=5:6, d = 2}$ (block bottom) and
-#| $x_{t=5:6, d = 0:1}$ (block bottom left). In this example,
-#| $\hat{x}_{t=6, d = 1}$ has already been imputed using the same approach,
-#| and we treat it as known going forward. This process is repeated across
-#| the reporting triangle to estimate all values outlined in the dashed lines.'
+#|    triangle, moving from left to right and bottom to top. In this cases, we
+#|    are imputing $x_{t=6, d = 2}$ and $x_{t=5, d= 2}$ assuming that the ratio
+#|    between $x_{t=1:4, d = 2}$ (block top), and $x_{t=1:4, d=0:1}$
+#|    (block top left) holds for for $x_{t=5:6, d = 2}$ (block bottom) and
+#|    $x_{t=5:6, d = 0:1}$ (block bottom left). In this example,
+#|    $\\hat{x}_{t=6, d = 1}$ has already been imputed using the same approach,
+#|    and we treat it as known going forward. This process is repeated across
+#|    the reporting triangle to estimate all values outlined in the dashed lines.'
 knitr::include_graphics(file.path("..", "man", "figures", "schematic_fig.png"))
 ```
 

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -93,7 +93,8 @@ The multiplicative model works by iteratively "filling in" the reporting triangl
 #|    $x_{t=5:6, d = 0:1}$ (block bottom left). In this example,
 #|    $\\hat{x}_{t=6, d = 1}$ has already been imputed using the same approach,
 #|    and we treat it as known going forward. This process is repeated across
-#|    the reporting triangle to estimate all values outlined in the dashed lines.'
+#|    the reporting triangle to estimate all values outlined in the dashed
+#|    lines.'
 knitr::include_graphics(file.path("..", "man", "figures", "schematic_fig.png"))
 ```
 

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -45,7 +45,7 @@ Throughout this document and package, we will refer to these matrices, as well a
 
 | **Data Structure** | **Observations Only** | **Mixed (Obs + Predictions)** | **Pure Predictions Only** |
 |------------------|------------------|------------------|------------------|
-| **Matrix Format** | `reporting_matrix` (complete with observations)<br>`reporting_triangle` (contains NAs for missing observations) | `point_nowcast_matrix`<br>`nowcast_matrix` | `point_pred_matrix`<br>`pred_matrix`  (contains NAs in elements where there were observations) |
+| **Matrix Format** | `reporting_matrix` (complete with observations)<br>`reporting_triangle` (contains NAs for missing observations) | `point_nowcast_matrix`<br>`nowcast_matrix` | `point_pred_matrix`<br>`pred_matrix` (contains NAs in elements where there were observations) |
 | **List Format** | `reporting_matrix_list` (complete)<br>`reporting_triangle_list` (contains NAs for missing observations) | `nowcast_matrix_list` | `pred_matrix_list` |
 | **Vector Format (summed across delays)** | `observed_cases` | `point_nowcast`<br>`nowcast` | `point_pred`<br>`pred` |
 | **DataFrame Format** | \- | `nowcast_df` | `pred_df` |
@@ -84,10 +84,16 @@ In the case where we have missing values in the bottom right (i.e. we have a rep
 The multiplicative model works by iteratively "filling in" the reporting triangle starting from the bottom left, and moving column by column from left to right until the bottom right of the triangle is filled in.
 
 ```{r squares}
-# nolint start
 #| echo = FALSE,
-#| fig.cap = 'Visual description of the iterative “completing” of the reporting triangle, moving from left to right and bottom to top. In this cases, we are imputing $x_{t=6, d = 2}$ and $x_{t=5, d= 2}$ assuming that the ratio between $x_{t=1:4, d = 2}$ (block top), and $x_{t=1:4, d=0:1}$ (block top left) holds for for $x_{t=5:6, d = 2}$ (block bottom) and $x_{t=5:6, d = 0:1}$ (block bottom left). In this example, $\\hat{x}_{t=6, d = 1}$ has already been imputed using the same approach, and we treat it as known going forward. This process is repeated across the reporting triangle to estimate all values outlined in the dashed lines.'
-# nolint end
+#| fig.cap = 'Visual description of the iterative “completing” of the reporting
+#| triangle, moving from left to right and bottom to top. In this cases, we are
+#| imputing $x_{t=6, d = 2}$ and $x_{t=5, d= 2}$ assuming that the ratio
+#| between $x_{t=1:4, d = 2}$ (block top), and $x_{t=1:4, d=0:1}$
+#| (block top left) holds for for $x_{t=5:6, d = 2}$ (block bottom) and
+#| $x_{t=5:6, d = 0:1}$ (block bottom left). In this example,
+#| $\hat{x}_{t=6, d = 1}$ has already been imputed using the same approach,
+#| and we treat it as known going forward. This process is repeated across
+#| the reporting triangle to estimate all values outlined in the dashed lines.'
 knitr::include_graphics(file.path("..", "man", "figures", "schematic_fig.png"))
 ```
 


### PR DESCRIPTION
## Description

This PR closes #132. It removes the `#nolint` in the code chunk so that the caption of the figure renders as it should. I have confirmed the preview renders as expected. 


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
