### PR TITLE
Hot fix: Move from error to warning in `estimate_dispersion()`

### DIFF
--- a/R/estimate_dispersion.R
+++ b/R/estimate_dispersion.R
@@ -14,6 +14,7 @@
 #' @param n Integer indicating the number of reporting matrices to use to
 #'    estimate the dispersion parameters.
 #' @importFrom checkmate assert_integerish
+#' @importFrom cli cli_abort cli_warn
 #' @returns Vector of length one less than the number of columns in the
 #'    latest reporting triangle, with each element representing the estimate
 #'    of the dispersion parameter for each delay d, starting at delay d=1.
@@ -85,7 +86,7 @@ estimate_dispersion <- function(
     )
   }
   if (!any(sapply(list_of_obs, anyNA))) {
-    cli_abort(
+    cli_warning(
       message =
         "`trunc_rep_tri_list` does not contain any NAs"
     )

--- a/R/estimate_dispersion.R
+++ b/R/estimate_dispersion.R
@@ -86,7 +86,7 @@ estimate_dispersion <- function(
     )
   }
   if (!any(sapply(list_of_obs, anyNA))) {
-    cli_warning(
+    cli_warn(
       message =
         "`trunc_rep_tri_list` does not contain any NAs"
     )

--- a/tests/testthat/test-estimate_dispersion.R
+++ b/tests/testthat/test-estimate_dispersion.R
@@ -99,7 +99,13 @@ test_that("Error conditions are properly handled", {
 ### Test 4: Edge Cases ---------------------------------------------------------
 test_that("Edge cases are handled properly", {
   # Empty lists
-  expect_error(estimate_dispersion(list(), list(), n = 0))
+  expect_error(expect_warning(estimate_dispersion(list(), list(), n = 0)))
+
+  # No NAs---------------------------------------------------------------------
+  expect_warning(estimate_dispersion(
+    valid_nowcasts,
+    lapply(valid_nowcasts, round)
+  ))
 
   # NA-filled matrices (This should error!)
   na_nowcasts <- list(matrix(NA, 2, 3), matrix(NA, 1, 3))


### PR DESCRIPTION
## Description

This was an overly strict error message. We should allow the user to pass in all complete observations for the list of `trunc_rep_tri_lists()`, which would be the case if they estimated the delay from a complete reporting triangle (which they can). Therefore this should be a warning. 


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
