### PR TITLE
Issue 157: enable observations to be aggregated 

### DIFF
--- a/R/get_nowcast_pred_draws.R
+++ b/R/get_nowcast_pred_draws.R
@@ -209,12 +209,14 @@ get_nowcast_pred_draws <- function(point_nowcast_matrix,
 #' nowcast_draw
 get_nowcast_draw <- function(point_nowcast_matrix,
                              reporting_triangle,
-                             dispersion) {
+                             dispersion,
+                             ...) {
   # Generate a single draw of the predictions
   pred_counts <- get_nowcast_pred_draw(
     point_nowcast_matrix,
     reporting_triangle,
-    dispersion
+    dispersion,
+    ...
   )
 
   # Combine with observations
@@ -226,6 +228,7 @@ get_nowcast_draw <- function(point_nowcast_matrix,
 #' Generate multiple draws of a nowcast combining observed and predicted values
 #'
 #' @inheritParams get_nowcast_pred_draws
+#' @param ... Additional arguments pass to `get_nowcast_pred_draws()`
 #' @returns Dataframe containing information for multiple draws with columns
 #'  for the reference time (`time`), the predicted counts (`pred_count`), and
 #'  the draw number (`draw`).
@@ -254,14 +257,16 @@ get_nowcast_draw <- function(point_nowcast_matrix,
 get_nowcast_draws <- function(point_nowcast_matrix,
                               reporting_triangle,
                               dispersion,
-                              draws = 1000) {
+                              draws = 1000,
+                              ...) {
   reference_times <- seq_len(nrow(point_nowcast_matrix))
 
   draws_df_list <- lapply(seq_len(draws), function(i) {
     pred_counts <- get_nowcast_draw(
       point_nowcast_matrix,
       reporting_triangle,
-      dispersion
+      dispersion,
+      ...
     )
 
     return(data.frame(

--- a/R/get_nowcast_pred_draws.R
+++ b/R/get_nowcast_pred_draws.R
@@ -104,8 +104,17 @@ get_nowcast_pred_draw <- function(point_nowcast_matrix,
 #' )
 #' reporting_triangle <- generate_triangle(reporting_matrix)
 #' combine_obs_with_pred(pred_counts, reporting_triangle)
-combine_obs_with_pred <- function(predicted_counts, reporting_triangle) {
-  obs_counts <- rowSums(reporting_triangle, na.rm = TRUE)
+combine_obs_with_pred <- function(predicted_counts,
+                                  reporting_triangle,
+                                  fun_to_aggregate = sum,
+                                  k = 1) {
+  obs_counts <- rollapply(
+    rowSums(reporting_triangle, na.rm = TRUE),
+    k,
+    fun_to_aggregate,
+    fill = NA,
+    align = "right"
+  )
   return(obs_counts + predicted_counts)
 }
 
@@ -220,7 +229,11 @@ get_nowcast_draw <- function(point_nowcast_matrix,
   )
 
   # Combine with observations
-  draw <- combine_obs_with_pred(pred_counts, reporting_triangle)
+  draw <- combine_obs_with_pred(
+    pred_counts,
+    reporting_triangle,
+    ...
+  )
 
   return(draw)
 }

--- a/man/get_nowcast_draw.Rd
+++ b/man/get_nowcast_draw.Rd
@@ -4,7 +4,7 @@
 \alias{get_nowcast_draw}
 \title{Generate a single draw of a nowcast combining observed and predicted values}
 \usage{
-get_nowcast_draw(point_nowcast_matrix, reporting_triangle, dispersion)
+get_nowcast_draw(point_nowcast_matrix, reporting_triangle, dispersion, ...)
 }
 \arguments{
 \item{point_nowcast_matrix}{Matrix of point nowcast predictions and

--- a/man/get_nowcast_draws.Rd
+++ b/man/get_nowcast_draws.Rd
@@ -8,7 +8,8 @@ get_nowcast_draws(
   point_nowcast_matrix,
   reporting_triangle,
   dispersion,
-  draws = 1000
+  draws = 1000,
+  ...
 )
 }
 \arguments{
@@ -27,6 +28,8 @@ minus one to the maximum delay.}
 
 \item{draws}{Integer indicating the number of draws of the predicted
 nowcast vector to generate. Default is \code{1000}.}
+
+\item{...}{Additional arguments pass to \code{get_nowcast_pred_draws()}}
 }
 \value{
 Dataframe containing information for multiple draws with columns

--- a/tests/testthat/test-get_nowcast_draws.R
+++ b/tests/testthat/test-get_nowcast_draws.R
@@ -1,32 +1,35 @@
 test_that(
-  "get_nowcast_draws: returns a dataframe with correct structure", {
-  point_nowcast_matrix <- matrix(
-    c(
-      100, 50, 30, 20,
-      90, 45, 25, 16.8,
-      80, 40, 21.2, 19.5,
-      70, 34.5, 15.4, 9.1
-    ),
-    nrow = 4,
-    byrow = TRUE
-  )
-  dispersion <- c(0.8, 12.4, 9.1)
-  reporting_triangle <- generate_triangle(point_nowcast_matrix)
+  "get_nowcast_draws: returns a dataframe with correct structure",
+  {
+    point_nowcast_matrix <- matrix(
+      c(
+        100, 50, 30, 20,
+        90, 45, 25, 16.8,
+        80, 40, 21.2, 19.5,
+        70, 34.5, 15.4, 9.1
+      ),
+      nrow = 4,
+      byrow = TRUE
+    )
+    dispersion <- c(0.8, 12.4, 9.1)
+    reporting_triangle <- generate_triangle(point_nowcast_matrix)
 
-  result <- get_nowcast_draws(
-    point_nowcast_matrix, reporting_triangle, dispersion, draws = 100
-  )
+    result <- get_nowcast_draws(
+      point_nowcast_matrix, reporting_triangle, dispersion,
+      draws = 100
+    )
 
-  expect_is(result, "data.frame")
-  expect_identical(
-    nrow(result),
-    as.integer(100 * nrow(point_nowcast_matrix))
-  )
-  expect_identical(ncol(result), 3L)
-  expect_true(all(c("pred_count", "time", "draw") %in% names(result)))
-  expect_length(unique(result$draw), 100L)
-  expect_identical(nrow(result), as.integer(100 * nrow(point_nowcast_matrix)))
-})
+    expect_is(result, "data.frame")
+    expect_identical(
+      nrow(result),
+      as.integer(100 * nrow(point_nowcast_matrix))
+    )
+    expect_identical(ncol(result), 3L)
+    expect_true(all(c("pred_count", "time", "draw") %in% names(result)))
+    expect_length(unique(result$draw), 100L)
+    expect_identical(nrow(result), as.integer(100 * nrow(point_nowcast_matrix)))
+  }
+)
 
 test_that("get_nowcast_draws: draws are distinct and properly indexed", {
   # Setup test data
@@ -145,3 +148,59 @@ test_that("get_nowcast_draws: function works with different number of draws", {
     as.integer(n_draws * nrow(point_nowcast_matrix))
   )
 })
+
+test_that(
+  "get_nowcast_draws: ingests k and fun to aggregate appropriately",
+  {
+    point_nowcast_matrix <- matrix(
+      c(
+        50, 80, 100, 40,
+        100, 50, 30, 20,
+        90, 45, 25, 16.8,
+        80, 40, 21.2, 19.5,
+        70, 34.5, 15.4, 9.1
+      ),
+      nrow = 5,
+      byrow = TRUE
+    )
+    dispersion <- c(0.8, 12.4, 9.1)
+    reporting_triangle <- generate_triangle(point_nowcast_matrix)
+
+    result_with_rolling_sum <- get_nowcast_draws(
+      point_nowcast_matrix,
+      reporting_triangle,
+      dispersion,
+      draws = 100,
+      fun_to_aggregate = sum,
+      k = 2
+    )
+    result <- get_nowcast_draws(
+      point_nowcast_matrix,
+      reporting_triangle,
+      dispersion,
+      draws = 100
+    )
+
+    # Test that result_with_rolling_sum is roughly double,
+    # which should be true for both the observations and the
+    # predictions
+    sum_result <- sum(result$pred_count[result$time != 1])
+    sum_result_rolling_sum <- sum(
+      result_with_rolling_sum$pred_count[result_with_rolling_sum$time != 1],
+      na.rm = TRUE
+    )
+    expect_equal(sum_result_rolling_sum / sum_result, 2, tol = 0.2)
+
+    # The sum of the first two time points should be the same as the value
+    # at t=2 for the rolling sum
+    expect_equal(
+      sum(result$pred_count[result$time <= 2]),
+      sum(result_with_rolling_sum$pred_count[result_with_rolling_sum$time == 2])
+    )
+    # All draws should be the same
+    expect_equal(
+      result_with_rolling_sum$pred_count[result_with_rolling_sum$time == 2 & result_with_rolling_sum$draw == 2],
+      result_with_rolling_sum$pred_count[result_with_rolling_sum$time == 2 & result_with_rolling_sum$draw == 1]
+    )
+  }
+)


### PR DESCRIPTION
## Description

This PR closes #157. This adds additional arguments to be passed to `get_nowcast_draw()` and `get_nowcast_draws()` as `...`. `combine_obs_with_pred` now has arguments for `fun_to_aggregate` and `k` so that the observations are also aggregated in the same way. 

[Describe the changes that you made in this pull request.]

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
