### PR TITLE
Hot fix: right alignment 

### DIFF
--- a/R/get_nowcast_pred_draws.R
+++ b/R/get_nowcast_pred_draws.R
@@ -67,12 +67,15 @@ get_nowcast_pred_draw <- function(point_nowcast_matrix,
   )
   n_horizons <- length(dispersion)
   max_t <- nrow(point_nowcast_pred_matrix)
-  mean_pred <- rollapply(
-    rowSums(point_nowcast_pred_matrix, na.rm = TRUE)[(max_t - n_horizons + 1):max_t], # nolint
+  mean_pred_long <- rollapply(
+    rowSums(point_nowcast_pred_matrix, na.rm = TRUE), # nolint
     k,
-    fun_to_aggregate
+    fun_to_aggregate,
+    align = "right",
+    fill = NA
   ) # nolint
   # Nowcast predictions only (these are reversed, first element is horizon 0)
+  mean_pred <- mean_pred_long[(max_t - n_horizons + 1):max_t]
   draw_pred <- rnbinom(n = n_horizons, size = rev(dispersion), mu = mean_pred)
   # Pad with 0s for the fully observed rows, which are before
   # the max_t - n_horizons

--- a/tests/testthat/test-get_nowcast_draws.R
+++ b/tests/testthat/test-get_nowcast_draws.R
@@ -219,8 +219,10 @@ test_that("get_nowcast_draws: longer k aggregates correctly", {
   pt_nowcast_mat <- generate_pt_nowcast_mat(triangle)
   dispersion <- c(10, 10, 10)
 
-  expected_mean <- rollsum(rowSums(pt_nowcast_mat),
-    k = 5, align = "right",
+  expected_mean <- rollapply(rowSums(pt_nowcast_mat),
+    5,
+    sum,
+    align = "right",
     fill = NA
   )
 

--- a/tests/testthat/test-get_nowcast_draws.R
+++ b/tests/testthat/test-get_nowcast_draws.R
@@ -211,7 +211,7 @@ test_that(
 
 test_that("get_nowcast_draws: longer k aggregates correctly", {
   set.seed(123)
-  rep_mat <- matrix(sample(1:20, size = 4 * 10, replace = TRUE),
+  rep_mat <- matrix(sample.int(1, 20, size = 4 * 10, replace = TRUE),
     nrow = 10, ncol = 4
   )
   triangle <- generate_triangle(rep_mat)


### PR DESCRIPTION
## Description
This was accidentally left aligning, and we currently only support right alignment. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the calculation of rolling aggregations for predicted nowcast values, ensuring correct alignment and handling of missing values.
- **Tests**
	- Added a new test to verify correct aggregation behavior with longer rolling windows, including handling of NA values and variability across draws.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->