### PR TITLE
Issue 162: add a test for returning the dispersion parameters by horizon

### DIFF
--- a/tests/testthat/test-estimate_dispersion.R
+++ b/tests/testthat/test-estimate_dispersion.R
@@ -473,7 +473,7 @@ test_that("estimate_dispersion: returns known dispersion parameters", { # nolint
   trunc_rep_tri_list <- list()
   pt_nowcast_mat_list <- list()
   reporting_triangle_list <- list()
-  disp_params <- c(800, 600, 700, 1000)
+  disp_param <- 10000
   for (i in 1:20) {
     trunc_rep_tri_orig <- reporting_triangle[1:(max_t - i), ]
     trunc_pt_nowcast_mat <- pt_nowcast_mat[1:(max_t - i), ]
@@ -481,12 +481,13 @@ test_that("estimate_dispersion: returns known dispersion parameters", { # nolint
     # For the last 4 horizons, replace each row with negative binomial draws
     # with a mean of the point nowcast matrix
     trunc_rep_tri <- trunc_rep_tri_orig
+    # Add uncertainty to each horizon 1:4
     for (j in 1:4) {
       max_t_loop <- nrow(trunc_rep_tri_orig)
       trunc_rep_tri[max_t_loop - j + 1, ] <- rnbinom(
         n = ncol(trunc_rep_tri_orig),
         mu = trunc_pt_nowcast_mat[max_t_loop - j + 1, ],
-        size = disp_params[j]
+        size = disp_param
       )
     }
     trunc_rep_tri[is.na(trunc_rep_tri_orig)] <- NA
@@ -511,6 +512,6 @@ test_that("estimate_dispersion: returns known dispersion parameters", { # nolint
     reporting_triangle_list
   )
 
-  expect_true(all(dispersion > 450)) # Can't distinguish more specific
+  expect_true(all(dispersion > 700)) # Can't distinguish more specific
   # dispersion values
 })


### PR DESCRIPTION
## Description

This PR closes #162. Here I am using the one point nowcast matrix as the expectation for everything and am not recomputing any triangles based on iterative delay estimates, I am just passing in the truncated point nowcast matrices as the expectation, and the observations (`trunc_rep_tri`) are obtained via sampling from a negative binomial with a mean given by the point nowcast and a dispersion parameter for the respective horizon. We have to use high values of the dispersion to approximate the poisson distribution, otherwise the dispersion in the sum of the elements is not the same as the dispersion in the individual elements. 

However, this doesn't return the exact dispersion values used as an input-- I don't think the method is able to distinguish well between already high degrees of dispersion (it seems to change with chance when I rerun after setting the seed). I think this may be due to either insufficient samples (number of reporting triangles) or just a limitation of the method (which we should probably note). Also worked even less well with very low counts (which is to be expected but also worth noting). 




## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify that dispersion parameter estimates exceed 700 when using simulated data with known high dispersion characteristics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->