### PR TITLE
Issue # 164: distinguish between the delays in delay pmf

### DIFF
--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -72,10 +72,10 @@ We will use the following to abbreviations to shorten names in the code:
 We can use a reporting matrix to compute an empirical estimate of the delay distribution, $\pi(d)$. The empirical delay distribution, $\pi(d)$ can be computed directly from the reporting matrix $X$
 
 $$
-\pi(d)= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
+\pi(d)= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d'=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d'}}
 $$
 
-Where the numerator is the sum of all the observations across reference times $t$ for a particular delay $d$, and the denominator is the sum across all reference times $t$ and delays $d$.
+Where the numerator is the sum of all the observations across reference times $t$ for a particular delay $d$ of interest, and the denominator is the sum across all reference times $t$ and indexed delays in the reporting matrix $d'$.
 
 ## Estimate of the delay distribution from a reporting triangle
 


### PR DESCRIPTION
## Description

This PR closes #164. This PR edits the `model_definition.Rmd` in the formula for the delay PMF, distinguishing between the point mass of the delay being estimated and the delays you are summing over in the numerator. 

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
