### PR TITLE
Issue 176: Change requirements on number of rows in `generate_pt_nowcast_mat()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # baselinenowcast 0.0.0.1000
 
+-   Change the requirement so that the number of rows used for delay estimation need not be greater than or equal to the number of columns, but isntead that at least one row contains a full set of observations.
 -   Bug fix to change the requirement so that the sum of the elements in the `structure` vector must not be greater than the number of columns.
 -   Add support for passing in a restricted set of functions to the `estimate_dispersion()` function to transform the "target" dataset across reference dates.
 -   Implements a safe iterator in the step where retrospective point nowcasts are generated from a list of retrospective reporting triangles, ensuring that the iterations continue even if not all retrospective point nowcasts can be generated.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # baselinenowcast 0.0.0.1000
 
--   Change the requirement so that the number of rows used for delay estimation need not be greater than or equal to the number of columns, but isntead that at least one row contains a full set of observations.
+-   Change the requirement so that the number of rows used for delay estimation need not be greater than or equal to the number of columns, but instead that at least one row contains a full set of observations.
 -   Bug fix to change the requirement so that the sum of the elements in the `structure` vector must not be greater than the number of columns.
 -   Add support for passing in a restricted set of functions to the `estimate_dispersion()` function to transform the "target" dataset across reference dates.
 -   Implements a safe iterator in the step where retrospective point nowcasts are generated from a list of retrospective reporting triangles, ensuring that the iterations continue even if not all retrospective point nowcasts can be generated.

--- a/R/generate_pt_nowcast_mat_list.R
+++ b/R/generate_pt_nowcast_mat_list.R
@@ -165,19 +165,10 @@ generate_pt_nowcast_mat <- function(reporting_triangle,
   if (n > nrow(reporting_triangle)) {
     cli_abort(
       message = c(
-        "The number of observations specified for delay estimation is greater ",
-        "than the minimum number of rows in the ",
-        "reporting triangle. Either remove the reporting triangles that do ",
-        "not contain sufficient data, or lower `n`."
-      )
-    )
-  }
-  if (n > nrow(reporting_triangle)) {
-    cli_abort(
-      message = c(
         "The number of observations (rows) specified for delay estimation ",
         "must be less than or equal to the number of rows of the reporting ",
-        "triangle."
+        "triangle. Either remove the reporting triangles that do ",
+        "not contain sufficient data, or lower `n`."
       )
     )
   }

--- a/R/generate_pt_nowcast_mat_list.R
+++ b/R/generate_pt_nowcast_mat_list.R
@@ -166,19 +166,30 @@ generate_pt_nowcast_mat <- function(reporting_triangle,
     cli_abort(
       message = c(
         "The number of observations specified for delay estimation is greater ",
-        "than the minimum number of rows in all of the retrospective ",
-        "reporting triangles. Either remove the reporting triangles that do ",
-        "not contain sufficient data, or lower `n_history_delay`"
+        "than the minimum number of rows in the ",
+        "reporting triangle. Either remove the reporting triangles that do ",
+        "not contain sufficient data, or lower `n`."
       )
     )
   }
-  if (n < ncol(reporting_triangle)) {
+  if (n > nrow(reporting_triangle)) {
     cli_abort(
       message = c(
-        "The number of observations specified for delay estimation is less ",
-        "than one plus the number of columns in the retrospective reporting ",
-        "triangles. The delay distribution can only be estimated from at ",
-        "at least the number of columns in the reporting triangle."
+        "The number of observations (rows) specified for delay estimation ",
+        "must be less than or equal to the number of rows of the reporting ",
+        "triangle."
+      )
+    )
+  }
+  n_rows <- nrow(reporting_triangle)
+  has_complete_row <- any(
+    rowSums(is.na(reporting_triangle[(n_rows - n + 1):n_rows, ])) == 0
+  )
+  if (isFALSE(has_complete_row)) {
+    cli_abort(
+      message = c(
+        "The rows used for delay estimation in the reporting triangle must ",
+        "contain at least one row with no missing observations."
       )
     )
   }

--- a/tests/testthat/test-generate_pt_nowcast_mat.R
+++ b/tests/testthat/test-generate_pt_nowcast_mat.R
@@ -90,15 +90,14 @@ test_that("generate_pt_nowcast_mat errors when n is incompatible", {
       test_triangle,
       n = 8
     )
-  ) # nolint
+  )
   # Custom n_history_delay is too low
   expect_error(
     generate_pt_nowcast_mat(
       test_triangle,
       n = 3
-    ),
-    regexp = "The number of observations specified for delay estimation is less"
-  ) # nolint
+    )
+  )
 })
 
 test_that("generate_pt_nowcast_mat can take in another delay PMF", {
@@ -110,4 +109,52 @@ test_that("generate_pt_nowcast_mat can take in another delay PMF", {
   last_row <- result[5, ]
   pmf <- last_row / sum(last_row)
   expect_equal(pmf, external_delay_pmf, tolerance = 0.01)
+})
+
+test_that("generate_pt_nowcast_mat generates the correct result on a ragged triangle", { # nolint
+  delay_pmf <- c(0.4, 0.3, 0.2, 0.05, 0.05)
+  partial_counts <- c(80, 100, 180, 80, 140)
+
+  # Create a complete triangle based on the known delay PMF
+  triangle <- lapply(partial_counts, function(x) x * delay_pmf)
+  triangle <- do.call(rbind, triangle)
+  triangle <- generate_triangle(triangle, structure = c(1, 2))
+
+  result <- generate_pt_nowcast_mat(
+    triangle
+  )
+  cols <- colSums(result[3:5, ])
+  pmf <- cols / sum(cols)
+  expect_equal(pmf, delay_pmf, tolerance = 0.01)
+})
+
+test_that("generate_pt_nowcast_mat generates the correct result on a ragged triangle with fewer rows than columns", { # nolint
+  delay_pmf <- c(0.4, 0.3, 0.2, 0.05, 0.05)
+  partial_counts <- c(80, 100, 180)
+
+  # Create a complete triangle based on the known delay PMF
+  triangle <- lapply(partial_counts, function(x) x * delay_pmf)
+  triangle <- do.call(rbind, triangle)
+  triangle <- generate_triangle(triangle, structure = c(1, 2))
+
+  result <- generate_pt_nowcast_mat(
+    triangle
+  )
+  cols <- colSums(result[2:3, ])
+  pmf <- cols / sum(cols)
+  expect_equal(pmf, delay_pmf, tolerance = 0.01)
+})
+
+test_that("generate_pt_nowcast_mat errors when there are insufficient observations", { # nolint
+  delay_pmf <- c(0.4, 0.3, 0.2, 0.05, 0.05)
+  partial_counts <- c(80, 100)
+
+  # Create a complete triangle based on the known delay PMF
+  triangle <- lapply(partial_counts, function(x) x * delay_pmf)
+  triangle <- do.call(rbind, triangle)
+  triangle <- generate_triangle(triangle, structure = c(1, 2))
+
+  expect_error(generate_pt_nowcast_mat(
+    triangle
+  ))
 })


### PR DESCRIPTION
## Description

This PR closes #176. It changes the requirement, which was likely a holdover check from before we introduced support for ragged triangles, that required the number of rows to be greater than or equal to the number of columns in the reporting triangle. It replaces it with a check that, within the rows used for delay estimation, there exists at least one complete row of observations. 

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [X] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for delay estimation to ensure at least one complete row is present among the selected rows, providing clearer error messages when requirements are not met.

- **Tests**
  - Added new test cases to verify behavior with ragged triangles and known delay distributions.
  - Enhanced error handling tests for insufficient observations.

- **Documentation**
  - Updated changelog to clarify changes in delay estimation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->