### PR TITLE
Hot fix: `get_delay_estimate()` needs warnings if trying to estimate without a complete row

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # baselinenowcast 0.0.0.1000
 
+-   Add a check to ensure that sufficient `n` are specified for the delay estimate.
 -   Change the requirement so that the number of rows used for delay estimation need not be greater than or equal to the number of columns, but instead that at least one row contains a full set of observations.
 -   Bug fix to change the requirement so that the sum of the elements in the `structure` vector must not be greater than the number of columns.
 -   Add support for passing in a restricted set of functions to the `estimate_dispersion()` function to transform the "target" dataset across reference dates.

--- a/R/get_delay_estimate.R
+++ b/R/get_delay_estimate.R
@@ -1,5 +1,6 @@
 #' Estimate a delay distribution from a reporting triangle
-#' Provides an estimate of the reporting delay as a function
+#'
+#' @description Provides an estimate of the reporting delay as a function
 #'   of the delay, based on the reporting triangle and the specified maximum
 #'   delay and number of reference date observations to be used in the
 #'   estimation. This point estimate of the delay is computed empirically,
@@ -53,6 +54,29 @@ get_delay_estimate <- function(
     max_delay = max_delay,
     n = n
   )
+  if (n > nrow(reporting_triangle)) {
+    cli_abort(
+      message = c(
+        "The number of observations (rows) specified for delay estimation ",
+        "must be less than or equal to the number of rows of the reporting ",
+        "triangle. Either remove the reporting triangles that do ",
+        "not contain sufficient data, or lower `n`."
+      )
+    )
+  }
+
+  n_rows <- nrow(reporting_triangle)
+  has_complete_row <- any(
+    rowSums(is.na(reporting_triangle[(n_rows - n + 1):n_rows, ])) == 0
+  )
+  if (isFALSE(has_complete_row)) {
+    cli_abort(
+      message = c(
+        "The rows used for delay estimation in the reporting triangle must ",
+        "contain at least one row with no missing observations."
+      )
+    )
+  }
 
   # Filter the reporting_triangle down to relevant rows and columns
   trunc_triangle <- .prepare_triangle(reporting_triangle, max_delay, n)

--- a/R/get_delay_estimate.R
+++ b/R/get_delay_estimate.R
@@ -54,29 +54,6 @@ get_delay_estimate <- function(
     max_delay = max_delay,
     n = n
   )
-  if (n > nrow(reporting_triangle)) {
-    cli_abort(
-      message = c(
-        "The number of observations (rows) specified for delay estimation ",
-        "must be less than or equal to the number of rows of the reporting ",
-        "triangle. Either remove the reporting triangles that do ",
-        "not contain sufficient data, or lower `n`."
-      )
-    )
-  }
-
-  n_rows <- nrow(reporting_triangle)
-  has_complete_row <- any(
-    rowSums(is.na(reporting_triangle[(n_rows - n + 1):n_rows, ])) == 0
-  )
-  if (isFALSE(has_complete_row)) {
-    cli_abort(
-      message = c(
-        "The rows used for delay estimation in the reporting triangle must ",
-        "contain at least one row with no missing observations."
-      )
-    )
-  }
 
   # Filter the reporting_triangle down to relevant rows and columns
   trunc_triangle <- .prepare_triangle(reporting_triangle, max_delay, n)

--- a/R/validate.R
+++ b/R/validate.R
@@ -44,8 +44,8 @@
   if (nrow(triangle) < n) {
     cli_abort(
       message = c(
-        "Number of observations in input reporting triangle is insufficient for",
-        "user specified number of historical observations to use",
+        "Number of observations in input reporting triangle is insufficient",
+        "for the user specified number of historical observations to use",
         "for delay estimaton."
       )
     )

--- a/R/validate.R
+++ b/R/validate.R
@@ -44,9 +44,9 @@
   if (nrow(triangle) < n) {
     cli_abort(
       message = c(
-        "Number of observations in input data not sufficient for",
+        "Number of observations in input reporting triangle is insufficient for",
         "user specified number of historical observations to use",
-        "for estimaton."
+        "for delay estimaton."
       )
     )
   }
@@ -75,6 +75,21 @@
         "Reporting triangle contains NA values in elements other than ",
         "the bottom right of the matrix. Cannot produce nowcasts from this ",
         "triangle."
+      )
+    )
+  }
+
+  n_rows <- nrow(triangle)
+  has_complete_row <- any(
+    rowSums(is.na(triangle[(n_rows - n + 1):n_rows, ])) == 0
+  )
+  if (isFALSE(has_complete_row)) {
+    cli_abort(
+      message = c(
+        "The rows used for delay estimation in the reporting triangle must ",
+        "contain at least one row with no missing observations. Consider ",
+        "increasing `n` to ensure a complete row of the reporting triangle is ",
+        "being used for delay estimation."
       )
     )
   }

--- a/man/get_delay_estimate.Rd
+++ b/man/get_delay_estimate.Rd
@@ -2,16 +2,7 @@
 % Please edit documentation in R/get_delay_estimate.R
 \name{get_delay_estimate}
 \alias{get_delay_estimate}
-\title{Estimate a delay distribution from a reporting triangle
-Provides an estimate of the reporting delay as a function
-of the delay, based on the reporting triangle and the specified maximum
-delay and number of reference date observations to be used in the
-estimation. This point estimate of the delay is computed empirically,
-using an iterative algorithm starting from the most recent observations.
-This code was adapted from code written (under an MIT license)
-by the Karlsruhe Institute of Technology RESPINOW
-German Hospitalization Nowcasting Hub.
-Modified from: https://github.com/KITmetricslab/RESPINOW-Hub/blob/7cce3ae2728116e8c8cc0e4ab29074462c24650e/code/baseline/functions.R#L55 #nolint}
+\title{Estimate a delay distribution from a reporting triangle}
 \usage{
 get_delay_estimate(
   reporting_triangle,
@@ -41,7 +32,6 @@ indicating the point estimate of the empirical probability
 mass on each delay.
 }
 \description{
-Estimate a delay distribution from a reporting triangle
 Provides an estimate of the reporting delay as a function
 of the delay, based on the reporting triangle and the specified maximum
 delay and number of reference date observations to be used in the

--- a/tests/testthat/test-validate_triangle.R
+++ b/tests/testthat/test-validate_triangle.R
@@ -11,9 +11,32 @@ test_that(".validate_triangle accepts non-integer values in triangle", {
   expect_no_error(
     .validate_triangle(non_integer_triangle,
       max_delay = 1,
-      n = 1
+      n = 2
     )
   )
+})
+
+test_that(".validate_triangle errors if `n` is too low", {
+  valid_triangle <- matrix(
+    c(
+      80, 50, 10, 10,
+      100, 40, 31, 20,
+      95, 45, 21, NA,
+      82, 42, NA, NA,
+      70, NA, NA, NA
+    ),
+    nrow = 5,
+    byrow = TRUE
+  )
+  # Errors if user specified n is too low
+  expect_error(.validate_triangle(valid_triangle,
+    max_delay = 3,
+    n = 3
+  ))
+  # Doesn't error on default behavior
+  expect_no_error(.validate_triangle(valid_triangle,
+    max_delay = 3
+  ))
 })
 
 test_that(".validate_triangle requires input to be a matrix", {


### PR DESCRIPTION
## Description

This PR addresses a bug, which previously would not warn if the user provided a `n` that tried to estimate a delay from a reporting triangle without a complete row. 

Previous behavior:
```r
valid_triangle <- matrix(
    c(
      80, 50, 10, 10,
      100, 40, 31, 20,
      95, 45, 21, NA,
      82, 42, NA, NA,
      70, NA, NA, NA
    ),
    nrow = 5,
    byrow = TRUE
  )
get_delay_estimate(valid_triangle
   max_delay = 3,
   n = 3)
#> NA NA NA NA

```
New fixed behavior
```r
get_delay_estimate(valid_triangle
   max_delay = 3,
   n = 3)
#> Error in `.validate_triangle()`:
#> ! The rows used for delay estimation in the reporting triangle must
#> contain at least one row with no missing observations. Consider
#> increasing `n` to ensure a complete row of the reporting triangle is
#> being used for delay estimation.
#> Run `rlang::last_trace()` to see where the error occurred.

```
Changes made:
- added a check to `.validate_triangle()`
- added a test to `test-validate_triangle()`
- scope creep: documentation for `get_delay_estimate()` fixed as the description was being printed as the title

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [X] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation to ensure that at least one complete row is present among the last specified rows for delay estimation, providing clearer error messages if requirements are not met.

- **Documentation**
	- Updated function documentation and changelog to clarify recent changes and improve description formatting.

- **Tests**
	- Added new tests to verify correct error handling when insufficient data is provided for delay estimation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->