### PR TITLE
Issue 101: move nomenclature table and abbreviations to separate vignette 

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,6 +19,8 @@ navbar:
           href: articles/baselinenowcast.html
         - text: "Mathematical model"
           href: articles/model_definition.html
+        - text: "Nomenclature"
+          href: articles/nomenclature.html
 
 
 home:

--- a/vignettes/model_definition.Rmd
+++ b/vignettes/model_definition.Rmd
@@ -31,6 +31,7 @@ Such that $X_t = X_{t, \le D}$ is the “final” number of reported cases on ti
 $$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
 
 is the number of cases still missing after $d$ delay. We refer to $X_t$ to describe a random variable, $x_t$ for the corresponding observation, and $\hat{x}_t$ for an estimated/imputed value. The matrix of $x_{t,d}$ available at a given time $t^*$ is referred to as a reporting matrix. In the case where all $t+d>t^*$ have yet to be observed (e.g. $t^*$ is the current time), this reporting matrix is referred to as the reporting triangle, with all values in the bottom right corner of the triangle being missing, except for the first entry at $x_{t=t*, d = 0}$.
+For a description of the nowcasting terms being used in this document (e.g. reporting triangle) and their corresponding abbreviations in the package, please consult the [nowcasting nomenclature](nomenclature.html) vignette.
 
 |           | $d = 0$       | $d = 1$       | $d=2$          | $...$ | $d= D-1$         | $d= D$        |
 |-----------|-----------|-----------|-----------|-----------|-----------|-----------|
@@ -40,30 +41,6 @@ is the number of cases still missing after $d$ delay. We refer to $X_t$ to descr
 | $...$     | $...$         | $...$         | $...$          | $...$ | $...$            | $...$         |
 | $t=t^*-1$ | $x_{t^*-1,0}$ | $x_{t^*-1,1}$ | $x_{t^*-1,,2}$ | $...$ | $x_{t^*-1,,D-1}$ | $x_{t^*-1,D}$ |
 | $t=t^*$   | $x_{t^*,0}$   | $x_{t^*,1}$   | $x_{t^*,2}$    | $...$ | $x_{t^*,D-1}$    | $x_{t^*, D}$  |
-
-Throughout this document and package, we will refer to these matrices, as well as their corresponding vectors, using the following table. In this table, "point" refers to a point estimate. When not indicated, we are referring to a probabilistic draw from an observation model.
-
-| **Data Structure**                       | **Observations Only**                                                                                           | **Mixed (Obs + Predictions)**              | **Pure Predictions Only**                                                                     |
-|------------------|------------------|------------------|------------------|
-| **Matrix Format**                        | `reporting_matrix` (complete with observations)<br>`reporting_triangle` (contains NAs for missing observations) | `point_nowcast_matrix`<br>`nowcast_matrix` | `point_pred_matrix`<br>`pred_matrix` (contains NAs in elements where there were observations) |
-| **List Format**                          | `reporting_matrix_list` (complete)<br>`reporting_triangle_list` (contains NAs for missing observations)         | `nowcast_matrix_list`                      | `pred_matrix_list`                                                                            |
-| **Vector Format (summed across delays)** | `observed_cases`                                                                                                | `point_nowcast`<br>`nowcast`               | `point_pred`<br>`pred`                                                                        |
-| **DataFrame Format**                     | \-                                                                                                              | `nowcast_df`                               | `pred_df`                                                                                     |
-
-For example, we refer to the matrix with imputed point estimates for all $t+d>t^*$ as a point nowcast matrix, a matrix with a complete set of observations for all elements as a reporting matrix, and a matrix with only the predictions as a point prediction matrix.
-
-In package documentation, we will generally use a reporting triangle to refer to a diagonal reporting triangle, which is the special case of a reporting triangle where the reporting delays and reference times are indexed on the same scale. An example of a diagonal reporting triangle is one with daily reporting of daily data. The package also supports what we refer to as a ragged reporting triangle, an example of which would be daily reporting of data referenced only once per week.
-
-We will use the following to abbreviations to shorten names in the code:
-
-| **Long Name** | **Code Abbreviation** |
-|---------------|-----------------------|
-| reporting     | `rep`                 |
-| observed      | `obs`                 |
-| incomplete    | `inc`                 |
-| matrix        | `mat`                 |
-| point         | `pt`                  |
-| error         | `err`                 |
 
 # Point estimate of the delay distribution
 

--- a/vignettes/nomenclature.Rmd
+++ b/vignettes/nomenclature.Rmd
@@ -14,7 +14,6 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-# Nomenclature
 
 Throughout this package, we will refer to different nowcasting object lists, matrices, and vectors using the following table.
 In this table, "point" refers to a point estimate. When not indicated, we are referring to a probabilistic draw from an observation model.

--- a/vignettes/nomenclature.Rmd
+++ b/vignettes/nomenclature.Rmd
@@ -1,0 +1,43 @@
+---
+title: "Nomenclature for `baselinenowcast`"
+description: "Description of different nowcasting components and corresponding abbreviations"
+output:
+  bookdown::html_document2:
+  fig_caption: yes
+code_folding: show
+pkgdown:
+  as_is: true
+csl: https://raw.githubusercontent.com/citation-style-language/styles/master/apa-numeric-superscript-brackets.csl
+vignette: >
+  %\VignetteIndexEntry{Nowcasting nomenclature}
+%\VignetteEngine{knitr::rmarkdown}
+%\VignetteEncoding{UTF-8}
+---
+
+# Nomenclature
+
+Throughout this package, we will refer to different nowcasting object lists, matrices, and vectors using the following table.
+In this table, "point" refers to a point estimate. When not indicated, we are referring to a probabilistic draw from an observation model.
+
+| **Data Structure**                       | **Observations Only**                                                                                           | **Mixed (Obs + Predictions)**              | **Pure Predictions Only**                                                                     |
+  |------------------|------------------|------------------|------------------|
+  | **Matrix Format**                        | `reporting_matrix` (complete with observations)<br>`reporting_triangle` (contains NAs for missing observations) | `point_nowcast_matrix`<br>`nowcast_matrix` | `point_pred_matrix`<br>`pred_matrix` (contains NAs in elements where there were observations) |
+  | **List Format**                          | `reporting_matrix_list` (complete)<br>`reporting_triangle_list` (contains NAs for missing observations)         | `nowcast_matrix_list`                      | `pred_matrix_list`                                                                            |
+  | **Vector Format (summed across delays)** | `observed_cases`                                                                                                | `point_nowcast`<br>`nowcast`               | `point_pred`<br>`pred`                                                                        |
+  | **DataFrame Format**                     | \-                                                                                                              | `nowcast_df`                               | `pred_df`                                                                                     |
+
+  For example, we refer to the matrix with imputed point estimates for all $t+d>t^*$ as a point nowcast matrix, a matrix with a complete set of observations for all elements as a reporting matrix, and a matrix with only the predictions as a point prediction matrix.
+
+In package documentation, we will generally use a reporting triangle to refer to a diagonal reporting triangle, which is the special case of a reporting triangle where the reporting delays and reference times are indexed on the same scale. An example of a diagonal reporting triangle is one with daily reporting of daily data. The package also supports what we refer to as a ragged reporting triangle, an example of which would be daily reporting of data referenced only once per week.
+
+We will use the following to abbreviations to shorten names in the code:
+
+  | **Long Name** | **Code Abbreviation** |
+  |---------------|-----------------------|
+  | reporting     | `rep`                 |
+  | observed      | `obs`                 |
+  | incomplete    | `inc`                 |
+  | matrix        | `mat`                 |
+  | point         | `pt`                  |
+  | error         | `err`                 |
+

--- a/vignettes/nomenclature.Rmd
+++ b/vignettes/nomenclature.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Nowcasting nomenclature`"
+title: "Nowcasting nomenclature"
 description: "Description of different nowcasting components and corresponding abbreviations"
 output:
   bookdown::html_document2:
@@ -10,8 +10,8 @@ pkgdown:
 csl: https://raw.githubusercontent.com/citation-style-language/styles/master/apa-numeric-superscript-brackets.csl
 vignette: >
   %\VignetteIndexEntry{Nowcasting nomenclature}
-%\VignetteEngine{knitr::rmarkdown}
-%\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
 # Nomenclature

--- a/vignettes/nomenclature.Rmd
+++ b/vignettes/nomenclature.Rmd
@@ -3,8 +3,8 @@ title: "Nowcasting nomenclature"
 description: "Description of different nowcasting components and corresponding abbreviations"
 output:
   bookdown::html_document2:
-  fig_caption: yes
-code_folding: show
+    fig_caption: yes
+    code_folding: show
 pkgdown:
   as_is: true
 csl: https://raw.githubusercontent.com/citation-style-language/styles/master/apa-numeric-superscript-brackets.csl

--- a/vignettes/nomenclature.Rmd
+++ b/vignettes/nomenclature.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Nomenclature for `baselinenowcast`"
+title: "Nowcasting nomenclature`"
 description: "Description of different nowcasting components and corresponding abbreviations"
 output:
   bookdown::html_document2:
@@ -40,4 +40,3 @@ We will use the following to abbreviations to shorten names in the code:
   | matrix        | `mat`                 |
   | point         | `pt`                  |
   | error         | `err`                 |
-


### PR DESCRIPTION
## Description

This PR closes #101. Moving table with descriptions of the different nowcasting components over to a separate vignette.  This is pretty lightweight, not sure if we want to add text but I think it should be a separate issue/PR to review/edit this after or part of  #167 and #143.


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Nomenclature" menu item under "Articles" in the navigation bar for easier access to terminology documentation.
  * Introduced a new "Nowcasting nomenclature" vignette that explains key terms, abbreviations, and data structures used throughout the package.

* **Documentation**
  * Updated the "Model Definition" vignette to reference the new nomenclature documentation, streamlining content and improving clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->