### PR TITLE
Hot fix: using wrong arg for estimate uncertainty

### DIFF
--- a/vignettes/baselinenowcast.Rmd
+++ b/vignettes/baselinenowcast.Rmd
@@ -413,9 +413,9 @@ Next, we will use the retrospective reporting triangles, the point nowcast matri
 
 ``` r
 disp_params <- estimate_uncertainty(
-  pt_nowcast_matrices = retro_pt_nowcast_mat_list,
-  trunc_reporting_triangles = trunc_rep_tri_list,
-  reporting_triangles = retro_rep_tri_list,
+  point_nowcast_matrices = retro_pt_nowcast_mat_list,
+  truncated_reporting_triangles = trunc_rep_tri_list,
+  retro_reporting_triangles = retro_rep_tri_list,
   n = n_retrospective_nowcasts
 )
 ```

--- a/vignettes/baselinenowcast.Rmd.orig
+++ b/vignettes/baselinenowcast.Rmd.orig
@@ -366,9 +366,9 @@ Next, we will use the retrospective reporting triangles, the point nowcast matri
 
 ```{r estimate-dispersion}
 disp_params <- estimate_uncertainty(
-  pt_nowcast_matrices = retro_pt_nowcast_mat_list,
-  trunc_reporting_triangles = trunc_rep_tri_list,
-  reporting_triangles = retro_rep_tri_list,
+  point_nowcast_matrices = retro_pt_nowcast_mat_list,
+  truncated_reporting_triangles = trunc_rep_tri_list,
+  retro_reporting_triangles = retro_rep_tri_list,
   n = n_retrospective_nowcasts
 )
 ```


### PR DESCRIPTION
## Description
Vignette wasn't properly updated when argument names changed. Need to figure out why this wasn't caught in CI. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parameter names in the usage examples for improved clarity and consistency. No changes to functionality or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->