### PR TITLE
Hot fix: remove warning if off by 1 due to odd number of reference times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cache
 .DS_Store
 .Rproj.user
 *.Rproj
+*.Rdata
 !inst/extdata/*.rds
 /doc/
 /Meta/

--- a/R/allocate_reference_times.R
+++ b/R/allocate_reference_times.R
@@ -287,7 +287,8 @@ allocate_reference_times <- function(reporting_triangle,
 
   prop_delay_used <- n_history_delay / n_used
 
-  if (prop_delay_used != prop_delay) {
+  if (prop_delay_used != prop_delay &&
+    abs(n_history_delay - n_retrospective_nowcasts) > 1) {
     cli_warn(
       message = c(
         "{prop_delay} reference times were specified for delay estimation but due to minimum requirements had to be reallocated.", # nolint

--- a/R/allocate_reference_times.R
+++ b/R/allocate_reference_times.R
@@ -299,9 +299,9 @@ allocate_reference_times <- function(reporting_triangle,
     if (flag_req_uncertainty) {
       cli_alert_info("This is due to the minumim requirement for the number of retrospective nowcasts for uncertainty estimation ({n_min_retro_nowcasts}).") # nolint
     } else if (flag_req_delay) {
-      cli_alert_info("This is due to the minumim requirement for the number of reference times needed for delay estimation ({n_min_delay}).")
+      cli_alert_info("This is due to the minumim requirement for the number of reference times needed for delay estimation ({n_min_delay}).") # nolint
     } else {
-      cli_alert_info("`prop_delay` not identical to the proprtion of reference times used for delay estimation due to rounding.")
+      cli_alert_info("`prop_delay` not identical to the proprtion of reference times used for delay estimation due to rounding.") # nolint
     }
   }
 

--- a/R/allocate_reference_times.R
+++ b/R/allocate_reference_times.R
@@ -288,10 +288,9 @@ allocate_reference_times <- function(reporting_triangle,
   prop_delay_used <- n_history_delay / n_used
 
   if (round(prop_delay_used, 3) != round(prop_delay, 3)) {
-    cli_warn(
-      message = c(
-        "{prop_delay} reference times were specified for delay estimation but due to minimum requirements or rounding had to be reallocated.", # nolint
-        "i" = "{round(prop_delay_used,3)} of reference times used for delay estimation." # nolint
+    cli_alert_info(
+      text = c(
+        "{prop_delay} reference times were specified for delay estimation but {round(prop_delay_used,3)} of reference times used for delay estimation." # nolint
       )
     )
   }

--- a/R/allocate_reference_times.R
+++ b/R/allocate_reference_times.R
@@ -287,7 +287,7 @@ allocate_reference_times <- function(reporting_triangle,
 
   prop_delay_used <- n_history_delay / n_used
 
-  if (prop_delay_used != prop_delay) {
+  if (round(prop_delay_used, 3) != round(prop_delay, 3)) {
     cli_warn(
       message = c(
         "{prop_delay} reference times were specified for delay estimation but due to minimum requirements or rounding had to be reallocated.", # nolint

--- a/R/allocate_reference_times.R
+++ b/R/allocate_reference_times.R
@@ -289,9 +289,8 @@ allocate_reference_times <- function(reporting_triangle,
 
   if (round(prop_delay_used, 3) != round(prop_delay, 3)) {
     cli_alert_info(
-      text = c(
+      text =
         "{prop_delay} reference times were specified for delay estimation but {round(prop_delay_used,3)} of reference times used for delay estimation." # nolint
-      )
     )
   }
 

--- a/R/allocate_reference_times.R
+++ b/R/allocate_reference_times.R
@@ -287,11 +287,10 @@ allocate_reference_times <- function(reporting_triangle,
 
   prop_delay_used <- n_history_delay / n_used
 
-  if (prop_delay_used != prop_delay &&
-    abs(n_history_delay - n_retrospective_nowcasts) > 1) {
+  if (prop_delay_used != prop_delay) {
     cli_warn(
       message = c(
-        "{prop_delay} reference times were specified for delay estimation but due to minimum requirements had to be reallocated.", # nolint
+        "{prop_delay} reference times were specified for delay estimation but due to minimum requirements or rounding had to be reallocated.", # nolint
         "i" = "{round(prop_delay_used,3)} of reference times used for delay estimation." # nolint
       )
     )

--- a/tests/testthat/test-allocate_reference_times.R
+++ b/tests/testthat/test-allocate_reference_times.R
@@ -55,7 +55,7 @@ test_that("allocate_reference_times properly scales delay and total training amo
     ncol = 5
   ) |> construct_triangle()
 
-  tv <- expect_warning(allocate_reference_times(
+  tv <- expect_message(allocate_reference_times(
     rep_tri,
     scale_factor = 2,
     prop_delay = 0.5
@@ -79,7 +79,7 @@ test_that("allocate_reference_times properly scales delay and total training amo
   expect_identical(tv3$n_history_delay, 5)
   expect_identical(tv3$n_retrospective_nowcasts, 15)
 
-  tv4 <- expect_warning(allocate_reference_times(
+  tv4 <- expect_message(allocate_reference_times(
     rep_tri,
     scale_factor = 3,
     prop_delay = 0.25
@@ -105,7 +105,7 @@ test_that("allocate_reference_times handles rounding with a warning", {
     ncol = 6
   ) |> construct_triangle()
 
-  tv <- expect_warning(allocate_reference_times(
+  tv <- expect_message(allocate_reference_times(
     rep_tri,
     scale_factor = 3,
     prop_delay = 0.5
@@ -172,7 +172,7 @@ test_that("allocate_reference_times warns when user or defaults don't meet minim
       reporting_triangle = rep_tri7,
       prop_delay = 0.9
     ),
-    regexp = "reference times were specified for delay estimation but due to minimum" # nolint
+    regexp = "7 reference times available and 12 are specified."
   ) # nolint
   expect_identical(tv7$n_history_delay, 5)
   expect_identical(tv7$n_retrospective_nowcasts, 2)
@@ -188,7 +188,7 @@ test_that("allocate_reference_times warns when user or defaults don't meet minim
       reporting_triangle = rep_tri8,
       prop_delay = 0.3
     ),
-    regexp = "reference times were specified for delay estimation but due to minimum" # nolint
+    regexp = "7 reference times available and 12 are specified." # nolint
   ) # nolint
   expect_identical(tv8$n_history_delay, 5)
   expect_identical(tv8$n_retrospective_nowcasts, 2)
@@ -279,7 +279,7 @@ test_that("allocate_reference_times allocates properly with no user specificatio
     allocate_reference_times(
       reporting_triangle = rep_tri4
     ),
-    regexp = "reference times were specified for delay estimation but due to minimum" # nolint
+    regexp = "8 reference times available and 12 are specified." # nolint
   )
   expect_identical(tv4$n_history_delay, 6)
   expect_identical(tv4$n_retrospective_nowcasts, 2)
@@ -294,7 +294,7 @@ test_that("allocate_reference_times allocates properly with no user specificatio
     allocate_reference_times(
       reporting_triangle = rep_tri5
     ),
-    regexp = "reference times were specified for delay estimation but due to minimum" # nolint
+    regexp = "9 reference times available and 15 are specified." # nolint
   )
   expect_identical(tv5$n_history_delay, 7)
   expect_identical(tv5$n_retrospective_nowcasts, 2)
@@ -309,7 +309,7 @@ test_that("allocate_reference_times allocates properly with no user specificatio
     allocate_reference_times(
       reporting_triangle = rep_tri6
     ),
-    regexp = "reference times were specified for delay estimation but due to minimum" # nolint
+    regexp = "60 reference times available and 117 are specified." # nolint
   )
 
   expect_identical(tv6$n_history_delay, 50)
@@ -325,7 +325,7 @@ test_that("allocate_reference_times allocates properly with no user specificatio
     allocate_reference_times(
       reporting_triangle = rep_tri7
     ),
-    regexp = "reference times were specified for delay estimation but due to minimum" # nolint
+    regexp = "55 reference times available and 114 are specified." # nolint
   )
   expect_identical(tv7$n_history_delay, 47)
   expect_identical(tv7$n_retrospective_nowcasts, 8)
@@ -362,12 +362,12 @@ test_that("allocate_reference_times warns and reallocates appropriately when suf
     nrow = 14,
     ncol = 4
   ) |> construct_triangle()
-  tv <- expect_warning(
+  tv <- expect_message(
     allocate_reference_times(
       reporting_triangle = rep_tri,
       prop_delay = 0.95
     ),
-    regexp = "reference times were specified for delay estimation but due to minimum" # nolint
+    regexp = "0.95 reference times were specified for delay estimation but" # nolint
   )
 })
 

--- a/tests/testthat/test-allocate_reference_times.R
+++ b/tests/testthat/test-allocate_reference_times.R
@@ -112,6 +112,21 @@ test_that("allocate_reference_times handles rounding with a warning", {
   ))
   expect_identical(tv$n_history_delay, 7)
   expect_identical(tv$n_retrospective_nowcasts, 8)
+
+  rep_tri2 <- matrix(
+    data = 1,
+    nrow = 100,
+    ncol = 31
+  ) |> construct_triangle()
+
+  # Don't warn when prop delay is basically equivalent
+  tv2 <- expect_no_warning(allocate_reference_times(
+    rep_tri2,
+    scale_factor = 3,
+    prop_delay = 0.667
+  ))
+  expect_identical(tv2$n_history_delay, 60)
+  expect_identical(tv2$n_retrospective_nowcasts, 30)
 })
 
 test_that("allocate_reference_times warns when user or defaults don't meet minimum requirements, and reallocates accordingly.", { # nolint

--- a/tests/testthat/test-allocate_reference_times.R
+++ b/tests/testthat/test-allocate_reference_times.R
@@ -98,6 +98,22 @@ test_that("allocate_reference_times properly scales delay and total training amo
   expect_identical(tv5$n_retrospective_nowcasts, 3)
 })
 
+test_that("allocate_reference_times handles rounding without warning", {
+  rep_tri <- matrix(
+    data = 1,
+    nrow = 20,
+    ncol = 6
+  ) |> construct_triangle()
+
+  tv <- expect_no_warning(allocate_reference_times(
+    rep_tri,
+    scale_factor = 3,
+    prop_delay = 0.5
+  ))
+  expect_identical(tv$n_history_delay, 7)
+  expect_identical(tv$n_retrospective_nowcasts, 8)
+})
+
 test_that("allocate_reference_times warns when user or defaults don't meet minimum requirements, and reallocates accordingly.", { # nolint
 
   # Test the default works when their is less than 3* max delay of data

--- a/tests/testthat/test-allocate_reference_times.R
+++ b/tests/testthat/test-allocate_reference_times.R
@@ -98,14 +98,14 @@ test_that("allocate_reference_times properly scales delay and total training amo
   expect_identical(tv5$n_retrospective_nowcasts, 3)
 })
 
-test_that("allocate_reference_times handles rounding without warning", {
+test_that("allocate_reference_times handles rounding with a warning", {
   rep_tri <- matrix(
     data = 1,
     nrow = 20,
     ncol = 6
   ) |> construct_triangle()
 
-  tv <- expect_no_warning(allocate_reference_times(
+  tv <- expect_warning(allocate_reference_times(
     rep_tri,
     scale_factor = 3,
     prop_delay = 0.5


### PR DESCRIPTION
## Description

This PR fixes the current warning messaging in `allocate_reference_times()`, so that if `prop_delay != prop_delay_used` the user is told this could be due to minimum requirements but could also be due to rounding. Added a test for the rounding case, both when it should and shouldn't warn.

Scope creep:
- add `.Rdata` to `.gitignore`

I think we might want to consider moving this from a warning to a message. Thoughts?


## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer warning when reallocation occurs due to minimum requirements or rounding.
- Bug Fixes
  - Improved allocation logic to account for rounding when matching target delay proportions, reducing false mismatches and ensuring consistent results in edge cases.
- Tests
  - Added test coverage for rounding scenarios, including cases with and without warnings, validating resulting counts.
- Chores
  - Updated ignore rules to exclude RData files and adjusted tracked directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->