### PR TITLE
Hot fix: linting on all PRs not just to main

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -2,8 +2,6 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 name: lint-changed-files


### PR DESCRIPTION
## Description

This PR edits the GitHub workflow to run linting checks on all PRs not just those into main. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Continuous integration linting now runs on all pull requests, not only those targeting the main branch.
  - This change affects repository workflows only; there are no changes to application behavior, UI, or performance.
  - Existing checks and steps are unchanged; manual trigger remains available.
  - No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->