### PR TITLE
Remove unused uncertainty_model parameter from estimate_uncertainty_retro

### DIFF
--- a/R/estimate_uncertainty_retro.R
+++ b/R/estimate_uncertainty_retro.R
@@ -75,7 +75,6 @@ estimate_uncertainty_retro <- function(
     max_delay = ncol(reporting_triangle) - 1,
     structure = detect_structure(reporting_triangle),
     delay_pmf = NULL,
-    uncertainty_model = fit_by_horizon,
     ...) {
   .validate_triangle(reporting_triangle)
 
@@ -121,7 +120,6 @@ estimate_uncertainty_retro <- function(
     truncated_reporting_triangles = trunc_rep_tri_list,
     retro_reporting_triangles = reporting_triangle_list,
     n = n_retrospective_nowcasts,
-    uncertainty_model = uncertainty_model,
     ...
   )
 

--- a/man/baselinenowcast.reporting_triangle.Rd
+++ b/man/baselinenowcast.reporting_triangle.Rd
@@ -76,7 +76,7 @@ This function ingests a single
 \code{\link{reporting_triangle}} object and generates a nowcast in the
 form of a \code{\link{baselinenowcast_df}} object.
 
-This function implements the full nowcasting workflow on a single reporting
+This function implements a nowcasting workflow for a single reporting
 triangle:
 \enumerate{
 \item \code{\link[=estimate_delay]{estimate_delay()}} - Estimate a reporting delay PMF

--- a/man/estimate_uncertainty_retro.Rd
+++ b/man/estimate_uncertainty_retro.Rd
@@ -11,7 +11,6 @@ estimate_uncertainty_retro(
   max_delay = ncol(reporting_triangle) - 1,
   structure = detect_structure(reporting_triangle),
   delay_pmf = NULL,
-  uncertainty_model = fit_by_horizon,
   ...
 )
 }
@@ -42,15 +41,6 @@ number of columns. Default is 1 (standard triangular structure).}
 starting at the first delay column in each of the matrices in
 \code{retro_reporting_triangles}. If a list, must of the same length as
 \code{retro_reporting_triangles}, with elements aligning. Default is \code{NULL}}
-
-\item{uncertainty_model}{Function that ingests a matrix of observations and a
-matrix of predictions and returns a vector that can be used to
-apply uncertainty using the same error model. Default is
-\code{fit_by_horizon} with arguments of \code{obs} matrix of observations and
-\code{pred} the matrix of predictions that fits each column (horizon)
-to a negative binomial observation model by default. The user can
-specify a different fitting model by replacing the
-\code{fit_model} argument in \code{fit_by_horizon}.}
 
 \item{...}{Additional arguments passed to \code{\link[=estimate_uncertainty]{estimate_uncertainty()}}.}
 }


### PR DESCRIPTION
## Summary
- Removed unused `uncertainty_model` parameter from `estimate_uncertainty_retro()` function signature
- Updated function call to remove passing this parameter
- Updated documentation accordingly

## Test plan
- Documentation builds successfully
- Function signature is now cleaner and matches actual implementation