### PR TITLE
Test out some more extreme examples

### DIFF
--- a/tests/testthat/test-apply_delay.R
+++ b/tests/testthat/test-apply_delay.R
@@ -333,7 +333,36 @@ test_that("apply_delay CDF can be not strictly increasing", {
 
   expect_false(anyNA(result))
 })
+test_that("apply_delay can handle more extreme negative backfill", {
+  triangle <- matrix(
+    c(
+      10, 6, -30, 10,
+      12, 7, -35, 15,
+      11, 6, -32, 12,
+      13, 7, -38, 18,
+      11, 6, -34, 14,
+      12, 7, -36, NA,
+      10, 6, NA, NA,
+      95, NA, NA, NA
+    ),
+    nrow = 8,
+    byrow = TRUE
+  )
+  delay_pmf <- estimate_delay(
+    reporting_triangle = triangle,
+    max_delay = 3,
+    n = 5,
+    preprocess = NULL
+  )
 
+  expect_error(
+    apply_delay(
+      reporting_triangle = triangle,
+      delay_pmf = delay_pmf
+    ),
+    regexp = "First entry of delay PMF (delay = 0) is negative"
+  )
+})
 test_that("apply_delay completes full workflow with negative PMF", {
   # Create triangle with negative values
   triangle <- matrix(

--- a/tests/testthat/test-estimate_delay.R
+++ b/tests/testthat/test-estimate_delay.R
@@ -226,6 +226,32 @@ test_that("estimate_delay with preprocess = NULL preserves negative values", {
   expect_true(any(delay_pmf < 0))
 })
 
+test_that("estimate_delay can handle more extreme negative backfill", {
+  triangle <- matrix(
+    c(
+      10, 6, -30, 10,
+      12, 7, -35, 15,
+      11, 6, -32, 12,
+      13, 7, -38, 18,
+      11, 6, -34, 14,
+      12, 7, -36, NA,
+      10, 6, NA, NA,
+      95, NA, NA, NA
+    ),
+    nrow = 8,
+    byrow = TRUE
+  )
+  delay_pmf <- estimate_delay(
+    reporting_triangle = triangle,
+    max_delay = 3,
+    n = 5,
+    preprocess = NULL
+  )
+
+  # This is all backwards bc sum(triangle) is negative, will fail
+  expect_true(all(delay_pmf[1:2] > 0))
+})
+
 test_that("estimate_delay with negative PMF produces non-increasing CDF", {
   # Use example data with negative values
   triangle_neg <- matrix(


### PR DESCRIPTION
## Description

Not suggesting we merge this but just wanted to demonstrate that even before the uncertainty model, I think we have fundamental issues with the method if the expected N/ sum(triangle) is negative. The delay PMF than has really non intuitive behaviour because the denominator is negative. 

Currently, this would get flagged and error in `apply_delay()` because the delay = 0 value would be negative.

I think one thing we could do is just add a check that sum(triangle) >0?? 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
