### PR TITLE
Issue 170: reference time allocation clarity

### DIFF
--- a/vignettes/modular_workflow.Rmd
+++ b/vignettes/modular_workflow.Rmd
@@ -141,7 +141,7 @@ n_history_delay <- tv$n_history_delay
 n_retrospective_nowcasts <- tv$n_retrospective_nowcasts
 ```
 
-Alternatively, if you wanted to directly specify the `n_history_delay` and `n_retrospective nowcasts` directly, you could do this.
+Alternatively, if you wanted to directly specify the `n_history_delay` and `n_retrospective_nowcasts` directly, you could do this.
 This might be useful if say you run your nowcast each week, but your data is daily, and you want to ensure that the number of weeks used for delay and uncertainty estimation is an integer number of weeks.
 
 # Estimate delay


### PR DESCRIPTION
## Description

This PR closes #170. It adds an example of when you might want to specify the `n_history_delay` and `n_retrospective_nowcasts` explicitly, say if you want it to use a whole number of weeks for each. This is added to the modular workflow vignette as this is the only place the user can set these reference time allocations, otherwise, the wrapper functions require them to specify using `prop_delay` and `scale_factor`. 

We could add an example of how you would use those functions to get an integer of the number of weeks e.g. `scale_factor = n_total_weeks *7/ max_delay`, prop_delay = `n_weeks_delay/n_total_weeks`

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an alternative pathway for specifying delay and retrospective nowcast parameters, enabling direct value assignment with integer-week alignment. Includes a practical example using 7-week periods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->