### PR TITLE
Issue 265: Fix multi-line vignette printing

### DIFF
--- a/vignettes/baselinenowcast.Rmd
+++ b/vignettes/baselinenowcast.Rmd
@@ -42,13 +42,10 @@ More details on the mathematical methods are provided in the [mathematical model
 As well as the `baselinenowcast` package this vignette also uses `epinowcast`, `ggplot2`, `tidyr`, and `dplyr`.
 For `baselinenowcast`, see the [installation instructions](https://github.com/epinowcast/baselinenowcast#installation).
 
-```{r setup2, include = FALSE}
+```{r setup2, message = FALSE, warning = FALSE, results = 'hide'}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>",
-  message = FALSE,
-  warning = FALSE,
-  results = "hide"
+  comment = "#>"
 )
 library(baselinenowcast)
 library(ggplot2)

--- a/vignettes/modular_workflow.Rmd
+++ b/vignettes/modular_workflow.Rmd
@@ -40,13 +40,10 @@ As well as the `baselinenowcast` package this vignette also uses `ggplot2`, `tid
 For `baselinenowcast`, see the [installation instructions](https://github.com/epinowcast/baselinenowcast#installation).
 
 
-```{r setup2, include = FALSE}
+```{r setup2, message = FALSE, warning = FALSE, results = 'hide'}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>",
-  message = FALSE,
-  warning = FALSE,
-  results = "hide"
+  comment = "#>"
 )
 library(baselinenowcast)
 library(ggplot2)

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -40,13 +40,10 @@ Note that all visits that originate in the emergency department are used for thi
 
 We use the `baselinenowcast` package for nowcasting, `dplyr`, and `tidyr` for data manipulation, `stringr` for parsing text data, `lubridate` for formatting dates, `ggplot2` for plotting, and `purrr` for mapping diagnoses codes to text fields in the data.
 For `baselinenowcast`, see the [installation instructions](https://github.com/epinowcast/baselinenowcast#installation).
-```{r setup2, include = FALSE}
+```{r setup2, message = FALSE, warning = FALSE, results = 'hide'}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>",
-  message = FALSE,
-  warning = FALSE,
-  results = "hide"
+  comment = "#>"
 )
 # Load packages
 library(baselinenowcast)


### PR DESCRIPTION
## Description

This PR closes #365. It modifies the knitr setup in each of the R coded vignettes, using `collapse = TRUE`, as we do in the `README.Rmd`

I have previewed locally (see screenshot below).


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized knitr options across vignettes for consistent example output (collapsed code, unified comment prefix).
  * Refined narrative in baselinenowcast vignette for clarity without changing content.
  * Added setup chunks in modular_workflow to ensure required libraries are loaded for reproducibility.
  * Updated chunk labels and global options in nssp_nowcast to align formatting across vignettes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->