### PR TITLE
Issue 426: add sentence about how 0-day delays are implicitly handled

### DIFF
--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -178,8 +178,10 @@ The choice of how to handle negative delays should be guided by the data experts
 
 For nowcasting, we want to compute the number of incident cases indexed by reference and report date, so we can aggregate by reference and report date and compute the delay distribution.
 ```{r}
-count_df <- clean_line_list_filtered |>
-  count(reference_date, report_date, name = "count")
+count_df <- count(clean_line_list_filtered,
+  reference_date, report_date,
+  name = "count"
+)
 head(count_df)
 ```
 

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -157,9 +157,12 @@ head(clean_line_list)
 ```
 ## Remove cases where the diagnoses code was reported before the visit start date by more than 24 hours
 
-Based on our understanding of the data generating process for this particular dataset, we believe that negative delays (instances where the time stamp of diagnosis-code reporting comes before the time stamp of the visit start date) with a magnitude of less than 24 hours likely reflects near synchronous recording and should be treated as a 0-day delay.
-In this case, we will set the report date to be the same day as the reference date (a 0-day delay).
-Whereas negative delays of greater than 24 hours we believe to reflect data entry errors, therefore, for the purpose of nowcasting and estimating the delay distribution, we will exclude these cases.
+Looking at this data, we can see that there is one case where there is a negative delay, which indicates that the time stamp of the diagnosis update was recorded before the start of the visit.
+Depending on the way that the data is generated, this could be a true negative value, for example if the patient had previously been tested elsewhere before arriving at the ED.
+Based on our understanding of the data generating process, we believe that negative delays with a magnitude of less than 24 hours likely reflects near simultaneous recording and should be treated as a 0-day delay.
+The 24-hour threshold here is specific to this dataset and should be investigated and set by the user.
+For negative delays of less than 24 hours, we will set the report date to be the same day as the reference date (a 0-day delay).
+Negative delays of greater than 24 hours we believe to reflect data entry errors, since in this dataset patient interactions always start in the ED, therefore, for the purpose of nowcasting and estimating the delay distribution, we will exclude these cases.
 
 ```{r}
 threshold_to_exclude <- -1
@@ -169,10 +172,17 @@ clean_line_list_filtered <- clean_line_list |>
     reference_date,
     report_date
   ))
+n_removed <- nrow(clean_line_list) - nrow(clean_line_list_filtered)
+n_rewritten <- nrow(clean_line_list_filtered |> filter(arrival_to_update_delay < 0))
+message("Number excluded due to negative delay greater than threshold: ", n_removed)
+message("Number rewritten to assume a 0-day delay: ", n_rewritten)
 ```
 
 In this synthetic dataset, this removed a case where the report date was reported to be greater than 7 days before the visit start date.
+There were no delays within 24 hours but on two different dates, so no delays were rewritten to have a 0-day delay.
+
 The choice of how to handle negative delays should be guided by the data experts and their understanding of the most likely reason for the observation to prevent introducing additional bias in this choice.
+Other ways of handling negative delays that might be plausible depending on the dataset include removing all negatives or setting all negative delays to 0-day delays, or using a different threshold for exclusion.
 
 ## Obtain counts of cases by reference date (visit date) and report date (time of first diagnosis)
 

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -165,7 +165,7 @@ Whereas negative delays of greater than 24 hours we believe to reflect data entr
 threshold_to_exclude <- -1
 clean_line_list_filtered <- clean_line_list |>
   filter(arrival_to_update_delay >= threshold_to_exclude) |>
-  mutate(report_date = dplyr::ifelse(arrival_to_update_delay < 0,
+  mutate(report_date = ifelse(arrival_to_update_delay < 0,
     reference_date,
     report_date
   ))

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -173,8 +173,14 @@ clean_line_list_filtered <- clean_line_list |>
     report_date
   ))
 n_removed <- nrow(clean_line_list) - nrow(clean_line_list_filtered)
-n_rewritten <- nrow(clean_line_list_filtered |> filter(arrival_to_update_delay < 0))
-message("Number excluded due to negative delay greater than threshold: ", n_removed)
+n_rewritten <- nrow(filter(
+  clean_line_list_filtered,
+  arrival_to_update_delay < 0
+))
+message(
+  "Number excluded due to negative delay greater than threshold: ",
+  n_removed
+)
 message("Number rewritten to assume a 0-day delay: ", n_rewritten)
 ```
 

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -173,10 +173,7 @@ clean_line_list_filtered <- clean_line_list |>
     report_date
   ))
 n_removed <- nrow(clean_line_list) - nrow(clean_line_list_filtered)
-n_rewritten <- nrow(filter(
-  clean_line_list_filtered,
-  arrival_to_update_delay < 0
-))
+n_rewritten <- sum(clean_line_list_filtered$arrival_to_update_delay < 0)
 message(
   "Number excluded due to negative delay greater than threshold: ",
   n_removed

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -155,24 +155,31 @@ clean_line_list <- first_bar_diagnosis |>
   )
 head(clean_line_list)
 ```
+## Remove cases where the diagnoses code was reported before the visit start date by more than 24 hours
+
+Based on our understanding of the data generating process for this particular dataset, we believe that negative delays (instances where th time stamp of the reporting of the diagnoses code comes before the time stamp of the visit start date), of less than 24 hours likely reflect a true 0-day delay in which both events did occur on the same day and were likely swapped.
+In this case, we will set the report date to be the same day as the reference date (a 0-day delay).
+Whereas negative delays of greater than 24 hours we believe to reflect data entry errors, therefore, for the purpose of nowcasting and estimating the delay distribution, we will exclude these cases.
+
+```{r}
+threshold_to_exclude <- -1
+clean_line_list_filtered <- clean_line_list |>
+  filter(arrival_to_update_delay >= threshold_to_exclude) |>
+  mutate(report_date = ifelse(arrival_to_update_delay < 0,
+    reference_date,
+    report_date
+  ))
+```
+
+In this synthetic dataset, this removed a case where the report date was reported to be greater than 7 days before the visit start date.
+The choice of how to handle negative delays should be guided by the data experts and their understanding of the most likely reason for the observation to prevent introducing additional bias in this choice.
 
 ## Obtain counts of cases by reference date (visit date) and report date (time of first diagnosis)
 
 For nowcasting, we want to compute the number of incident cases indexed by reference and report date, so we can aggregate by reference and report date and compute the delay distribution.
 ```{r}
-count_df_raw <- clean_line_list |>
-  count(reference_date, report_date, name = "count") |>
-  mutate(delay = as.integer(report_date - reference_date))
-```
-
-Looking at this data, we can see that there is one case where there is a negative delay of greater than a day, which indicates that the time stamp of the diagnosis update was recorded a day or more before the start of the visit.
-Depending on the way that the data is generated, this could be a true negative value, for example if the patient had previously been tested elsewhere before arriving at the ED, and this event is what we consider to be the primary event.
-In this case, patients interactions with the system always start in the ED, so negative values of more than a day are likely due to a data entry error.
-For this reason, we will will choose to exclude all the negative valued delays.
-However, because we discretise the time stamps to a day, negative valued delays that occur on the same date, e.g. within a few hours, will be included as they will be counted as 0-day delays.
-The choice of how to handle negative delays should be guided by the data experts and their understanding of the most likely reason for the observation to prevent introducing additional bias in this choice.
-```{r}
-count_df <- filter(count_df_raw, delay >= 0)
+count_df <- clean_line_list_filtered |>
+  count(reference_date, report_date, name = "count")
 head(count_df)
 ```
 

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -165,10 +165,12 @@ count_df_raw <- clean_line_list |>
   mutate(delay = as.integer(report_date - reference_date))
 ```
 
-Looking at this data, we can see that there is one case where there is a negative delay, which indicates that the time stamp of the diagnosis update was recorded before the start of the visit.
-Depending on the way that the data is generated, this could be a true negative value, for example if the patient had previously been tested elsewhere before arriving at the ED.
-In this case, patients interactions with the system always start in the ED, so this is likely due to a data entry error.
-For this reason, we will will choose to exclude all the negative valued delays, however, the choice of how to handle these should be guided be guided by the data experts and their understanding of the most likely reason for the observation to prevent introducing additional bias in this choice.
+Looking at this data, we can see that there is one case where there is a negative delay of greater than a day, which indicates that the time stamp of the diagnosis update was recorded a day or more before the start of the visit.
+Depending on the way that the data is generated, this could be a true negative value, for example if the patient had previously been tested elsewhere before arriving at the ED, and this event is what we consider to be the primary event.
+In this case, patients interactions with the system always start in the ED, so negative values of more than a day are likely due to a data entry error.
+For this reason, we will will choose to exclude all the negative valued delays.
+However, because we discretise the time stamps to a day, negative valued delays that occur on the same date, e.g. within a few hours, will be included as they will be counted as 0-day delays.
+The choice of how to handle negative delays should be guided by the data experts and their understanding of the most likely reason for the observation to prevent introducing additional bias in this choice.
 ```{r}
 count_df <- filter(count_df_raw, delay >= 0)
 head(count_df)

--- a/vignettes/nssp_nowcast.Rmd
+++ b/vignettes/nssp_nowcast.Rmd
@@ -157,7 +157,7 @@ head(clean_line_list)
 ```
 ## Remove cases where the diagnoses code was reported before the visit start date by more than 24 hours
 
-Based on our understanding of the data generating process for this particular dataset, we believe that negative delays (instances where th time stamp of the reporting of the diagnoses code comes before the time stamp of the visit start date), of less than 24 hours likely reflect a true 0-day delay in which both events did occur on the same day and were likely swapped.
+Based on our understanding of the data generating process for this particular dataset, we believe that negative delays (instances where the time stamp of diagnosis-code reporting comes before the time stamp of the visit start date) with a magnitude of less than 24 hours likely reflects near synchronous recording and should be treated as a 0-day delay.
 In this case, we will set the report date to be the same day as the reference date (a 0-day delay).
 Whereas negative delays of greater than 24 hours we believe to reflect data entry errors, therefore, for the purpose of nowcasting and estimating the delay distribution, we will exclude these cases.
 
@@ -165,7 +165,7 @@ Whereas negative delays of greater than 24 hours we believe to reflect data entr
 threshold_to_exclude <- -1
 clean_line_list_filtered <- clean_line_list |>
   filter(arrival_to_update_delay >= threshold_to_exclude) |>
-  mutate(report_date = ifelse(arrival_to_update_delay < 0,
+  mutate(report_date = dplyr::ifelse(arrival_to_update_delay < 0,
     reference_date,
     report_date
   ))


### PR DESCRIPTION
## Description

This PR closes #426. After discussing with @lauraajones2 we decided it would be better to be explicit about how this code is handling within the same day negative delays. In this case, we decided that we want to treat all negative delays that are less than 24 hours as 0-day delays, and all negative delays greater than 24 hours we want to exclude. 

This means that for delays between 0 and -1, we want to manually set these as having the same reference and report date. This prevents us from excluding the edge case when a patients report date is 11 pm one day and their visit start date is labeled as 1 am the next day. In this case, we will treat this as a visit date and a report date both of which occurred on the next day. 

This threshold for which we consider negative delays to be 0-day delays could be any number of hours e.g. 6, 12 etc. 


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the nowcast vignette with refined methodology for managing negative diagnosis-report delays. New approach includes filtering delays exceeding 24 hours negative, adjusting mild negative delays to same-day reporting, and improved narrative documentation. Changes clarify the impact on case count aggregation and data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->