### PR TITLE
Issue 432: fix vignette so missing values are visible

### DIFF
--- a/vignettes/baselinenowcast.Rmd
+++ b/vignettes/baselinenowcast.Rmd
@@ -211,7 +211,6 @@ plot_triangle <- ggplot(
   geom_tile() +
   scale_fill_gradient(low = "white", high = "blue") +
   labs(title = "Reporting triangle", x = "Delay", y = "Time") +
-  theme_bw() +
   scale_y_reverse()
 ```
 </details>


### PR DESCRIPTION
## Description

This PR closes #432. It removes the `theme_bw()` call to the plot of the reporting triangle so that it is visible when something has a count of 0 versus when it is missing. As pointed out by a user. 

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plot styling in documentation example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/epinowcast/baselinenowcast/pull/433)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->