### PR TITLE
Hot fix: add article to menu on site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -26,6 +26,8 @@ navbar:
           href: articles/nomenclature.html
         - text: "A case study nowcasting applied to the U.S. National Syndromic Surveillance Program (NSSP) data"
           href: articles/nssp_nowcast.html
+        - text: "An example of how to evaluate nowcast performance under different model specifications"
+          href: articles/evaluation_example.html
 
 # Code folding configuration
 code:


### PR DESCRIPTION
## Description

This PR adds to the `_pkgdown.yml` a menu item under articles to access the rendered `evaluation_example` vignette. Without this, there is no way to navigate to the vignette from the documentation.


## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new article link in the site navigation for “An example of how to evaluate nowcast performance under different model specifications,” making the example easier to find.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->