### PR TITLE
Issue 474: fix passing of args to `baselinenowcast()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,16 @@
+# baselinenowcast 0.2.2000
+
+## Package
+
+- Fix bugs in `baselinenowcast.reporting_triangle()` and `baselinenowcast.data.frame` which failed to pass the additional arguments to `estimate_uncertainty()` and `sample_nowcasts()` through to their subsequent calls. This meant that specifying the `ref_time_aggregator`as something other than the default failed to work as expected.
+
 # baselinenowcast 0.2.1000
 
 ## Package
 
 - Add `as_forecast_sample()` and `as_forecast_point()` S3 methods for `baselinenowcast_df` objects, enabling direct conversion of probabilistic or point nowcasts to `scoringutils` forecast objects for scoring against the latest observed counts (#418). `baselinenowcast_df` objects now carry a logical `nowcast` column flagging the right-truncated reference dates that were actually nowcast (as opposed to fully observed), and the converters use it to score only those dates.
--  Place every internal check, assert, and validate function next to its consumer (class invariants in `R/reporting_triangle-class.R` and `R/baselinenowcast_df-class.R`; per-caller helpers in the file that calls them) and remove `R/validate.R`. Generalise `assert_rep_tri_class()` with an `arg_name` argument and use it to replace duplicated inline class checks in `truncate_to_quantile()`, `truncate_to_delay()`, and the reporting triangle getters and methods (#300).
--  Add converters between `reporting_triangle` and [reviser](https://CRAN.R-project.org/package=reviser) vintages formats via `as_reviser_vintages()` and `as_reporting_triangle.tbl_pubdate()`, enabling use of reviser's vintage analysis and state space nowcasting methods alongside baselinenowcast's nowcasting functionality (#429).
+- Place every internal check, assert, and validate function next to its consumer (class invariants in `R/reporting_triangle-class.R` and `R/baselinenowcast_df-class.R`; per-caller helpers in the file that calls them) and remove `R/validate.R`. Generalise `assert_rep_tri_class()` with an `arg_name` argument and use it to replace duplicated inline class checks in `truncate_to_quantile()`, `truncate_to_delay()`, and the reporting triangle getters and methods (#300).
+- Add converters between `reporting_triangle` and [reviser](https://CRAN.R-project.org/package=reviser) vintages formats via `as_reviser_vintages()` and `as_reporting_triangle.tbl_pubdate()`, enabling use of reviser's vintage analysis and state space nowcasting methods alongside baselinenowcast's nowcasting functionality (#429).
 - Add `truncate_to_date()`, a date-based wrapper around `truncate_to_row()` that drops rows with reference dates after a given cutoff (#447).
 
 ## Documentation

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Package
 
-- Fix bugs in `baselinenowcast.reporting_triangle()` and `baselinenowcast.data.frame` which failed to pass the additional arguments to `estimate_uncertainty()` and `sample_nowcasts()` through to their subsequent calls. This meant that specifying the `ref_time_aggregator` as something other than the default failed to work as expected.
+- Fixed argument passing in `baselinenowcast.reporting_triangle()` and `baselinenowcast.data.frame` to `estimate_uncertainty()` and `sample_nowcasts()`.
 
 # baselinenowcast 0.2.1000
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Package
 
-- Fix bugs in `baselinenowcast.reporting_triangle()` and `baselinenowcast.data.frame` which failed to pass the additional arguments to `estimate_uncertainty()` and `sample_nowcasts()` through to their subsequent calls. This meant that specifying the `ref_time_aggregator`as something other than the default failed to work as expected.
+- Fix bugs in `baselinenowcast.reporting_triangle()` and `baselinenowcast.data.frame` which failed to pass the additional arguments to `estimate_uncertainty()` and `sample_nowcasts()` through to their subsequent calls. This meant that specifying the `ref_time_aggregator` as something other than the default failed to work as expected.
 
 # baselinenowcast 0.2.1000
 

--- a/R/baselinenowcast.R
+++ b/R/baselinenowcast.R
@@ -188,7 +188,8 @@ baselinenowcast.reporting_triangle <- function(
       reporting_triangle = processed_data,
       n_history_delay = tv$n_history_delay,
       n_retrospective_nowcasts = tv$n_retrospective_nowcasts,
-      uncertainty_model = uncertainty_model
+      uncertainty_model = uncertainty_model,
+      ...
     )
   }
 
@@ -431,7 +432,8 @@ baselinenowcast.data.frame <- function(
         delay_pmf = shared_delay_pmf,
         uncertainty_params = shared_uncertainty_params,
         preprocess = preprocess,
-        validate = FALSE
+        validate = FALSE,
+        ...
       )
     }, # nolint end
     .id = "name"

--- a/tests/testthat/test-baselinenowcast-dataframe.R
+++ b/tests/testthat/test-baselinenowcast-dataframe.R
@@ -824,3 +824,40 @@ test_that("baselinenowcast_test: ref_time_aggregator works correctly across all 
     }
   }
 })
+
+test_that("baselinenowcast with ref time aggregator is same with both dataframe and reporting triangle method", { # nolint
+  skip_if_not_installed("dplyr")
+  set.seed(123)
+  covid_data_single_group <- covid_data |>
+    filter(
+      age_group == "00-04",
+      location == "DE"
+    )
+  rep_tri <- as_reporting_triangle(covid_data_single_group)
+  result_7d_sum_tri <- suppressWarnings(
+    baselinenowcast(
+      rep_tri,
+      ref_time_aggregator = function(x) zoo::rollsum(x, k = 7, align = "right")
+    )
+  )
+  set.seed(123)
+  result_7d_sum_df <- suppressWarnings(
+    baselinenowcast(
+      covid_data_single_group,
+      strata_cols = c("age_group", "location"),
+      ref_time_aggregator = function(x) zoo::rollsum(x, k = 7, align = "right")
+    )
+  )
+
+  # Results should be the same regardless of the method used
+  expect_equal(
+    mean(result_7d_sum_tri$pred_count, na.rm = TRUE),
+    mean(result_7d_sum_df$pred_count, na.rm = TRUE),
+    tol = 0.01
+  )
+  expect_equal(
+    sd(result_7d_sum_tri$pred_count, na.rm = TRUE),
+    sd(result_7d_sum_df$pred_count, na.rm = TRUE),
+    tol = 0.01
+  )
+})

--- a/tests/testthat/test-baselinenowcast-dataframe.R
+++ b/tests/testthat/test-baselinenowcast-dataframe.R
@@ -828,11 +828,11 @@ test_that("baselinenowcast_test: ref_time_aggregator works correctly across all 
 test_that("baselinenowcast with ref time aggregator is same with both dataframe and reporting triangle method", { # nolint
   skip_if_not_installed("dplyr")
   set.seed(123)
-  covid_data_single_group <- covid_data |>
-    filter(
-      age_group == "00-04",
-      location == "DE"
-    )
+  covid_data_single_group <- filter(
+    covid_data,
+    age_group == "00-04",
+    location == "DE"
+  )
   rep_tri <- as_reporting_triangle(covid_data_single_group)
   result_7d_sum_tri <- suppressWarnings(
     baselinenowcast(

--- a/tests/testthat/test-baselinenowcast-dataframe.R
+++ b/tests/testthat/test-baselinenowcast-dataframe.R
@@ -695,3 +695,129 @@ test_that(paste0(
       theme_bw()
   }
 })
+
+test_that("baselinenowcast_test: ref_time_aggregator works correctly across all strata", { # nolint
+  set.seed(123)
+  result_default <- baselinenowcast_test(
+    data = covid_data,
+    strata_cols = c("age_group", "location")
+  )
+  set.seed(123)
+  result_7d_sum <- baselinenowcast_test(
+    data = covid_data,
+    strata_cols = c("age_group", "location"),
+    ref_time_aggregator = function(x) zoo::rollsum(x, k = 7, align = "right")
+  )
+
+  expect_s3_class(result_7d_sum, "data.frame")
+  expect_named(result_7d_sum, c(
+    "pred_count", "reference_date", "draw",
+    "output_type", "nowcast", "age_group",
+    "location"
+  ))
+
+  # The aggregated result should differ numerically from the default
+  # (k=7 rolling sum applies to nowcast targets, changing pred_count values)
+  expect_false(
+    identical(result_default$pred_count, result_7d_sum$pred_count)
+  )
+
+  max_ref_date <- max(result_default$reference_date)
+  mean_default <- mean(
+    result_default$pred_count[result_default$reference_date == max_ref_date],
+    na.rm = TRUE
+  )
+  mean_7d <- mean(
+    result_7d_sum$pred_count[result_7d_sum$reference_date == max_ref_date],
+    na.rm = TRUE
+  )
+
+  # 7-day sum draws should be larger in expectation than 1-day
+  expect_gt(mean_7d, mean_default)
+
+  # Per-stratum checks
+  strata <- unique(
+    result_default[, c("age_group", "location"), drop = FALSE]
+  )
+
+  # Every stratum in the default result should also appear in the 7d result
+  strata_7d <- unique(
+    result_7d_sum[, c("age_group", "location"), drop = FALSE]
+  )
+  expect_identical(
+    strata[order(strata$age_group, strata$location), ],
+    strata_7d[order(strata_7d$age_group, strata_7d$location), ]
+  )
+
+  for (i in seq_len(nrow(strata))) {
+    ag <- strata$age_group[i]
+    loc <- strata$location[i]
+
+    stratum_default <- result_default[
+      result_default$age_group == ag & result_default$location == loc,
+    ]
+    stratum_7d <- result_7d_sum[
+      result_7d_sum$age_group == ag & result_7d_sum$location == loc,
+    ]
+
+    # Each stratum should have the same reference dates in both results
+    expect_identical(
+      sort(unique(stratum_default$reference_date)),
+      sort(unique(stratum_7d$reference_date)),
+      label = paste0("reference dates match for age_group=", ag, ", location=", loc)
+    )
+
+    # Each stratum should have the same draws in both results
+    expect_identical(
+      sort(unique(stratum_default$draw)),
+      sort(unique(stratum_7d$draw)),
+      label = paste0("draw indices match for age_group=", ag, ", location=", loc)
+    )
+
+    # Within each stratum, the 7d result should differ from the default
+    # (the aggregator changes the pred_count values)
+    expect_false(
+      identical(stratum_default$pred_count, stratum_7d$pred_count),
+      label = paste0("pred_count differs for age_group=", ag, ", location=", loc)
+    )
+
+    # At the most recent reference date within each stratum, the 7-day
+    # rolling sum should yield larger draws in expectation than the default
+    max_date_stratum <- max(stratum_default$reference_date)
+    mean_default_stratum <- mean(
+      stratum_default$pred_count[
+        stratum_default$reference_date == max_date_stratum
+      ],
+      na.rm = TRUE
+    )
+    mean_7d_stratum <- mean(
+      stratum_7d$pred_count[
+        stratum_7d$reference_date == max_date_stratum
+      ],
+      na.rm = TRUE
+    )
+    expect_gt(
+      mean_7d_stratum, mean_default_stratum,
+      label = paste0(
+        "7d mean > default mean at max ref date for age_group=",
+        ag, ", location=", loc
+      )
+    )
+
+    # The first 6 reference dates within each stratum should produce NA
+    # pred_count for the 7d result (can't form a 7-element window)
+    sorted_dates <- sort(unique(stratum_7d$reference_date))
+    if (length(sorted_dates) >= 7) {
+      first_six_dates <- sorted_dates[1:6]
+      na_rows <- stratum_7d[
+        stratum_7d$reference_date %in% first_six_dates,
+      ]
+      expect_true(
+        all(is.na(na_rows$pred_count)),
+        label = paste0(
+          "first 6 ref dates are NA for age_group=", ag, ", location=", loc
+        )
+      )
+    }
+  }
+})

--- a/tests/testthat/test-baselinenowcast-dataframe.R
+++ b/tests/testthat/test-baselinenowcast-dataframe.R
@@ -764,21 +764,24 @@ test_that("baselinenowcast_test: ref_time_aggregator works correctly across all 
     expect_identical(
       sort(unique(stratum_default$reference_date)),
       sort(unique(stratum_7d$reference_date)),
-      label = paste0("reference dates match for age_group=", ag, ", location=", loc)
+      label = paste0("reference dates match for age_group=", ag, ",
+                     location=", loc)
     )
 
     # Each stratum should have the same draws in both results
     expect_identical(
       sort(unique(stratum_default$draw)),
       sort(unique(stratum_7d$draw)),
-      label = paste0("draw indices match for age_group=", ag, ", location=", loc)
+      label = paste0("draw indices match for age_group=", ag, ",
+                     location=", loc)
     )
 
     # Within each stratum, the 7d result should differ from the default
     # (the aggregator changes the pred_count values)
     expect_false(
       identical(stratum_default$pred_count, stratum_7d$pred_count),
-      label = paste0("pred_count differs for age_group=", ag, ", location=", loc)
+      label = paste0("pred_count differs for age_group=", ag, ",
+                     location=", loc)
     )
 
     # At the most recent reference date within each stratum, the 7-day

--- a/tests/testthat/test-baselinenowcast-reporting_triangle.R
+++ b/tests/testthat/test-baselinenowcast-reporting_triangle.R
@@ -321,3 +321,41 @@ test_that("baselinenowcast point estimate works with just enough reference times
   expect_false(anyNA(result$pred_count))
   expect_gt(nrow(result), 0)
 })
+
+test_that("baselinenowcast works with custom ref_time_aggregator", {
+  set.seed(123)
+  result_2d_sum <- baselinenowcast(
+    example_reporting_triangle,
+    ref_time_aggregator = function(x) zoo::rollsum(x, k = 2, align = "right")
+  )
+  set.seed(123)
+  result_default <- baselinenowcast(
+    example_reporting_triangle
+  )
+  # Both return a data frame with the same structure
+  expect_s3_class(result_2d_sum, "data.frame")
+  expect_named(result_2d_sum, c(
+    "pred_count", "reference_date", "draw",
+    "output_type",
+    "nowcast"
+  ))
+
+  # The aggregated result should differ numerically from the default
+  # (k=2 rolling sum applies to nowcast targets, changing pred_count values)
+  expect_false(
+    identical(result_default$pred_count, result_2d_sum$pred_count)
+  )
+
+  max_ref_date <- max(result_default$reference_date)
+  mean_default <- mean(
+    result_default$pred_count[result_default$reference_date == max_ref_date],
+    na.rm = TRUE
+  )
+  mean_2d <- mean(
+    result_2d_sum$pred_count[result_2d_sum$reference_date == max_ref_date],
+    na.rm = TRUE
+  )
+
+  # 2-day sum draws should be larger in expectation than 1-day
+  expect_gt(mean_2d, mean_default)
+})

--- a/tests/testthat/test-baselinenowcast-reporting_triangle.R
+++ b/tests/testthat/test-baselinenowcast-reporting_triangle.R
@@ -329,9 +329,9 @@ test_that("baselinenowcast works with custom ref_time_aggregator", {
     ref_time_aggregator = function(x) zoo::rollsum(x, k = 2, align = "right")
   ))
   set.seed(123)
-  result_default <- baselinenowcast(
+  result_default <- suppressWarnings(baselinenowcast(
     example_reporting_triangle
-  )
+  ))
   # Both return a data frame with the same structure
   expect_s3_class(result_2d_sum, "data.frame")
   expect_named(result_2d_sum, c(

--- a/tests/testthat/test-baselinenowcast-reporting_triangle.R
+++ b/tests/testthat/test-baselinenowcast-reporting_triangle.R
@@ -324,10 +324,10 @@ test_that("baselinenowcast point estimate works with just enough reference times
 
 test_that("baselinenowcast works with custom ref_time_aggregator", {
   set.seed(123)
-  result_2d_sum <- baselinenowcast(
+  result_2d_sum <- suppressWarnings(baselinenowcast(
     example_reporting_triangle,
     ref_time_aggregator = function(x) zoo::rollsum(x, k = 2, align = "right")
-  )
+  ))
   set.seed(123)
   result_default <- baselinenowcast(
     example_reporting_triangle


### PR DESCRIPTION
## Description

This PR closes #474.

This PR does the following:
- fixes the bugs where we failed to pass the `...` as additional arguments in the top-level `baselinenowcast.reporting_triangle` and `baselinenowcast.data.frame` methods
- add tests for both

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [X] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed additional options being dropped when using custom reference-time aggregation in nowcasting workflows.
  * Multi-stratum nowcasting now passes user settings through consistently across all strata.

* **Tests**
  * Added coverage for custom rolling aggregations in both single-triangle and multi-stratum runs.
  * Verified expected output structure, matching strata behavior, and changed predictions with rolling sums.

* **Documentation**
  * Updated release notes with the latest bug fix entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->